### PR TITLE
Explicitly type final as any[]

### DIFF
--- a/app/contestants/page.tsx
+++ b/app/contestants/page.tsx
@@ -19,7 +19,7 @@ export default function Contestants() {
             })
     }, [])
 
-    const final = []
+    const final: any[] = []
     return (
         <div>
           <h1 className="text-2xl text-center">Contestants This Season</h1>


### PR DESCRIPTION
The issue that you were running into with `final` implicitly having a type of `any[]` was likely it not being explicitly `any[]`.

I don't know if this is the sort of error that would prevent it from being able to build locally, but I was able to do so.