### PR TITLE
Feature/add scoring

### DIFF
--- a/__tests__/models/Team.js
+++ b/__tests__/models/Team.js
@@ -82,3 +82,47 @@ describe('Team isInPlay', () => {
         }
     })
 })
+
+describe('Team static getKey', () => {
+    it('should produce the same result reguardless of the order of the team contestant', () => {
+
+        // Arrange
+        const orderingOne = "Aname one & Bname two"
+        const orderingTwo = "Bname two & Aname one"
+
+        // Act
+        const resultOne = Team.getKey(orderingOne)
+        const resultTwo = Team.getKey(orderingTwo)
+
+        // Assert
+        expect(resultOne).toBe(resultTwo)
+    })
+
+    it('should produce the same result ignoring trailing whitespace', () => {
+
+        // Arrange
+        const expectedTeamName = "Aname one & Bname two"
+        const testTeamName = "Aname one & Bname two   "
+
+        // Act
+        const expectedResult = Team.getKey(expectedTeamName)
+        const testResult = Team.getKey(testTeamName)
+
+        // Assert
+        expect(testResult).toBe(expectedResult)
+    })
+
+    it('should produce the same result ignoring leading whitespace', () => {
+
+        // Arrange
+        const expectedTeamName = "Aname one & Bname two"
+        const testTeamName = "   Aname one & Bname two"
+
+        // Act
+        const expectedResult = Team.getKey(expectedTeamName)
+        const testResult = Team.getKey(testTeamName)
+
+        // Assert
+        expect(testResult).toBe(expectedResult)
+    })
+})

--- a/__tests__/models/Team.js
+++ b/__tests__/models/Team.js
@@ -84,7 +84,7 @@ describe('Team isInPlay', () => {
 })
 
 describe('Team static getKey', () => {
-    it('should produce the same result reguardless of the order of the team contestant', () => {
+    it('should produce the same result regardless of the order of the team contestant', () => {
 
         // Arrange
         const orderingOne = "Aname one & Bname two"

--- a/app/models/Team.tsx
+++ b/app/models/Team.tsx
@@ -28,5 +28,20 @@ export default class Team {
         return teamIsParticipating || teamHasNotYetBeenEliminated
     }
 
+    static getKey(teamName: string): string {
+        var seed = ""
+
+        const names = teamName
+            .split("&")
+            .map(s => s.trim() )
+
+        if (names[0][0] > names[1][0]) {
+            seed = names[1] + names[0]
+        }
+        else {
+            seed = names[0] + names[1]
+        }
+        return seed
+    }
 }
 

--- a/app/scoring/page.tsx
+++ b/app/scoring/page.tsx
@@ -26,7 +26,7 @@ export default async function Scoring() {
     const wikiContestants = await getWikipediaContestantData()
     const pageData = getTeamList(wikiContestants)
 
-    const teamDictionary = pageData.props.runners.reduce((acc, t) => {
+    const teamDictionary = pageData.props.runners.reduce((acc: Dictionary<any>, t: ITeam) => {
             acc[getKey(t.teamName)] = t
 
             return acc

--- a/app/scoring/page.tsx
+++ b/app/scoring/page.tsx
@@ -9,18 +9,6 @@ interface Dictionary<T> {
     [Key: string]: T;
 }
 
-function getKey(teamName: string): string {
-    const names = teamName.split("&").map(s => s.trim() )
-    var seed = ""
-    if (names[0][0] > names[1][0]) {
-        seed = names[1] + names[0]
-    }
-    else {
-        seed = names[0] + names[1]
-    }
-    return seed
-}
-
 export default async function Scoring() {
 
     const wikiContestants = await getWikipediaContestantData()

--- a/app/scoring/page.tsx
+++ b/app/scoring/page.tsx
@@ -54,6 +54,11 @@ export default async function Scoring() {
         roundScores.push(roundScore)
     }
 
+    const currentSelectedContestantTeamsList = currentSelectedContestantRanking.map(x => {
+        const foundTeam = teamDictionary[getKey(x)]
+        return foundTeam
+    })
+
     let grandTotal = 0
     return (
         <div>

--- a/app/scoring/page.tsx
+++ b/app/scoring/page.tsx
@@ -59,7 +59,7 @@ export default async function Scoring() {
         return foundTeam
     })
 
-    const contestantRoundScores = []
+    const contestantRoundScores: number[] = []
     for(let i = 0; i < numberOfRounds; i++) {
         const roundScore = currentSelectedContestantTeamsList.reduce(
             (acc: number, x: Team) => {

--- a/app/scoring/page.tsx
+++ b/app/scoring/page.tsx
@@ -10,6 +10,12 @@ export default async function Scoring() {
     const wikiContestants = await getWikipediaContestantData()
     const pageData = getTeamList(wikiContestants)
 
+    const teamDictionary = pageData.props.runners.reduce((acc, t) => {
+            acc[t.teamName] = t
+
+            return acc
+        }, {})
+
     const currentSelectedContestant = "Jacob"
 
     const currentSelectedContestantRanking = [ "Rob & Corey", "Jocelyn & Victor", "Morgan & Lena", "Greg & John", "Robbin & Chelsea", "Steve & Anna Leigh", "Ashlie & Todd", "Joel & Garrett", "Joe & Ian", "Malania & Andrea", "Liam & Yeremi", "Elizabeth & Iliana", "Alexandra & Sherida" ]
@@ -50,7 +56,9 @@ export default async function Scoring() {
                             <div className="basis-1/2">
                                 {currentSelectedContestantRanking.map(t => {
                                     return (<>
-                                        <p key={t+"current"}>{t}</p>
+                                        <p key={t+"current"}>
+                                            {teamDictionary[t].isParticipating ? t : <s>{t}</s> }
+                                        </p>
                                     </>)
                                 })}
                             </div>

--- a/app/scoring/page.tsx
+++ b/app/scoring/page.tsx
@@ -6,7 +6,15 @@ import Team from '../models/Team'
 import { shouldBeScored } from '../utils/teamListUtils'
 
 function getKey(teamName: string): string {
-    return teamName
+    const names = teamName.split("&").map(s => s.trim() )
+    var seed = ""
+    if (names[0][0] > names[1][0]) {
+        seed = names[1] + names[0]
+    }
+    else {
+        seed = names[0] + names[1]
+    }
+    return seed
 }
 
 export default async function Scoring() {

--- a/app/scoring/page.tsx
+++ b/app/scoring/page.tsx
@@ -5,6 +5,10 @@ import TeamList from '../components/teamList'
 import Team from '../models/Team'
 import { shouldBeScored } from '../utils/teamListUtils'
 
+function getKey(teamName: string): string {
+    return teamName
+}
+
 export default async function Scoring() {
 
     const wikiContestants = await getWikipediaContestantData()

--- a/app/scoring/page.tsx
+++ b/app/scoring/page.tsx
@@ -12,6 +12,8 @@ export default async function Scoring() {
 
     const currentSelectedContestant = "Jacob"
 
+    const currentSelectedContestantRanking = [ "Rob & Corey", "Jocelyn & Victor", "Morgan & Lena", "Greg & John", "Robbin & Chelsea", "Steve & Anna Leigh", "Ashlie & Todd", "Joel & Garrett", "Joe & Ian", "Malania & Andrea", "Liam & Yeremi", "Elizabeth & Iliana", "Alexandra & Sherida" ]
+
     const numberOfRounds = pageData.props.runners.reduce(
         (acc: number, x: ITeam) => {
             return x.eliminationOrder > acc ? x.eliminationOrder : acc
@@ -41,7 +43,18 @@ export default async function Scoring() {
 
                     return (<Fragment key={"round details"+roundNumber}>
                         <h2 key={"weekHeader"+roundNumber}className="text-xl">Week {roundNumber+1}</h2>
-                        <TeamList teamList={reverseTeamsList} roundNumber={roundNumber} />
+                        <div className="text-center flex">
+                            <div className="basis-1/2">
+                                <TeamList teamList={reverseTeamsList} roundNumber={roundNumber} />
+                            </div>
+                            <div className="basis-1/2">
+                                {currentSelectedContestantRanking.map(t => {
+                                    return (<>
+                                        <p key={t+"current"}>{t}</p>
+                                    </>)
+                                })}
+                            </div>
+                        </div>
                         <br/>
                         <p key={"weekTotal"+roundNumber}className="text-center">Weekly Total: {score}</p>
                         <p key={"grandTotal"+roundNumber}className="text-center">Grand Total: {grandTotal}</p>

--- a/app/scoring/page.tsx
+++ b/app/scoring/page.tsx
@@ -75,13 +75,7 @@ export default async function Scoring() {
                                 <TeamList teamList={reverseTeamsList} roundNumber={roundNumber} />
                             </div>
                             <div className="basis-1/2">
-                                {currentSelectedContestantRanking.map(t => {
-                                    return (<>
-                                        <p key={t+"current"}>
-                                            {teamDictionary[getKey(t)].isParticipating ? t : <s>{t}</s> }
-                                        </p>
-                                    </>)
-                                })}
+                                <TeamList teamList={currentSelectedContestantTeamsList} roundNumber={roundNumber} />
                             </div>
                         </div>
                         <br/>

--- a/app/scoring/page.tsx
+++ b/app/scoring/page.tsx
@@ -59,6 +59,18 @@ export default async function Scoring() {
         return foundTeam
     })
 
+    const contestantRoundScores = []
+    for(let i = 0; i < numberOfRounds; i++) {
+        const roundScore = currentSelectedContestantTeamsList.reduce(
+            (acc: number, x: Team) => {
+                const teamShouldBeScored = shouldBeScored(currentSelectedContestantTeamsList, x, i)
+
+                return teamShouldBeScored ? acc + 10 : acc
+            }, 0)
+        contestantRoundScores.push(roundScore)
+    }
+
+
     let grandTotal = 0
     return (
         <div>
@@ -67,6 +79,7 @@ export default async function Scoring() {
             <div className="text-center">
                 {roundScores.map((score, roundNumber) => {
                     grandTotal += score
+                    let contestantRoundScore = contestantRoundScores[roundNumber]
 
                     return (<Fragment key={"round details"+roundNumber}>
                         <h2 key={"weekHeader"+roundNumber}className="text-xl">Week {roundNumber+1}</h2>
@@ -79,7 +92,7 @@ export default async function Scoring() {
                             </div>
                         </div>
                         <br/>
-                        <p key={"weekTotal"+roundNumber}className="text-center">Weekly Total: {score}</p>
+                        <p key={"weekTotal"+roundNumber}className="text-center">Weekly Total: {contestantRoundScore}/{score}</p>
                         <p key={"grandTotal"+roundNumber}className="text-center">Grand Total: {grandTotal}</p>
                         <br/>
                         <br/>

--- a/app/scoring/page.tsx
+++ b/app/scoring/page.tsx
@@ -27,7 +27,7 @@ export default async function Scoring() {
     const pageData = getTeamList(wikiContestants)
 
     const teamDictionary = pageData.props.runners.reduce((acc: Dictionary<ITeam>, t: ITeam) => {
-            acc[getKey(t.teamName)] = t
+            acc[Team.getKey(t.teamName)] = t
 
             return acc
         }, {})
@@ -55,7 +55,7 @@ export default async function Scoring() {
     }
 
     const currentSelectedContestantTeamsList = currentSelectedContestantRanking.map(x => {
-        const foundTeam = teamDictionary[getKey(x)]
+        const foundTeam = teamDictionary[Team.getKey(x)]
         return foundTeam
     })
 

--- a/app/scoring/page.tsx
+++ b/app/scoring/page.tsx
@@ -26,7 +26,7 @@ export default async function Scoring() {
     const wikiContestants = await getWikipediaContestantData()
     const pageData = getTeamList(wikiContestants)
 
-    const teamDictionary = pageData.props.runners.reduce((acc: Dictionary<any>, t: ITeam) => {
+    const teamDictionary = pageData.props.runners.reduce((acc: Dictionary<ITeam>, t: ITeam) => {
             acc[getKey(t.teamName)] = t
 
             return acc

--- a/app/scoring/page.tsx
+++ b/app/scoring/page.tsx
@@ -30,7 +30,7 @@ export default async function Scoring() {
 
     const currentSelectedContestant = "Jacob"
 
-    const currentSelectedContestantRanking = [ "Rob & Corey", "Jocelyn & Victor", "Morgan & Lena", "Greg & John", "Robbin & Chelsea", "Steve & Anna Leigh", "Ashlie & Todd", "Joel & Garrett", "Joe & Ian", "Malania & Andrea", "Liam & Yeremi", "Elizabeth & Iliana", "Alexandra & Sherida" ]
+    const currentSelectedContestantRanking = [ "Corey McArthur & Rob McArthur", "Jocelyn Chao & Victor Limary", "Lena Franklin & Morgan Franklin", "Greg Franklin & John Franklin", "Chelsea Day & Robbin Tomich", "Anna Leigh Wilson & Steve Cargile", "Ashlie Martin & Todd Martin", "Garrett Smith & Joel Strasser", "Ian Todd & Joe Moskowitz", "Andrea Simpson & Malaina Hatcher", "Liam Hykel & Yeremi Hykel", "Elizabeth Rivera & Iliana Rivera", "Alexandra Lichtor & Sheridan Lichtor" ]
 
     const numberOfRounds = pageData.props.runners.reduce(
         (acc: number, x: ITeam) => {

--- a/app/scoring/page.tsx
+++ b/app/scoring/page.tsx
@@ -15,7 +15,7 @@ export default async function Scoring() {
     const pageData = getTeamList(wikiContestants)
 
     const teamDictionary = pageData.props.runners.reduce((acc, t) => {
-            acc[t.teamName] = t
+            acc[getKey(t.teamName)] = t
 
             return acc
         }, {})
@@ -61,7 +61,7 @@ export default async function Scoring() {
                                 {currentSelectedContestantRanking.map(t => {
                                     return (<>
                                         <p key={t+"current"}>
-                                            {teamDictionary[t].isParticipating ? t : <s>{t}</s> }
+                                            {teamDictionary[getKey(t)].isParticipating ? t : <s>{t}</s> }
                                         </p>
                                     </>)
                                 })}

--- a/app/scoring/page.tsx
+++ b/app/scoring/page.tsx
@@ -72,6 +72,7 @@ export default async function Scoring() {
 
 
     let grandTotal = 0
+    let contestantGrandTotal = 0
     return (
         <div>
             <h1 className="text-2xl text-center">Current Scoring for {currentSelectedContestant}</h1>
@@ -80,6 +81,7 @@ export default async function Scoring() {
                 {roundScores.map((score, roundNumber) => {
                     grandTotal += score
                     let contestantRoundScore = contestantRoundScores[roundNumber]
+                    contestantGrandTotal += contestantRoundScore
 
                     return (<Fragment key={"round details"+roundNumber}>
                         <h2 key={"weekHeader"+roundNumber}className="text-xl">Week {roundNumber+1}</h2>
@@ -93,7 +95,7 @@ export default async function Scoring() {
                         </div>
                         <br/>
                         <p key={"weekTotal"+roundNumber}className="text-center">Weekly Total: {contestantRoundScore}/{score}</p>
-                        <p key={"grandTotal"+roundNumber}className="text-center">Grand Total: {grandTotal}</p>
+                        <p key={"grandTotal"+roundNumber}className="text-center">Grand Total: {contestantGrandTotal}/{grandTotal}</p>
                         <br/>
                         <br/>
                     </Fragment>)

--- a/app/scoring/page.tsx
+++ b/app/scoring/page.tsx
@@ -5,6 +5,10 @@ import TeamList from '../components/teamList'
 import Team from '../models/Team'
 import { shouldBeScored } from '../utils/teamListUtils'
 
+interface Dictionary<T> {
+    [Key: string]: T;
+}
+
 function getKey(teamName: string): string {
     const names = teamName.split("&").map(s => s.trim() )
     var seed = ""


### PR DESCRIPTION
This will add scoring for a single hard coded player which is compared to a perfect score for the league. This will be built off of setting up a "perfect scoring" in #12 and may also come after sprucing up our testing strategy so we can be more confident in our changes. #17 

_Note: this doesn't work currently locally or otherwise for the following_
- [x] the hard coded team names don't know about the change to team names defined by both contestants full names (see the new test in #17 which asserts that)

_Note2: given #25 has been filed which suggests that we should re-evaluate the whole paradigm, I am trying not to let that strictly block this effort since this gets a bit closer to the vision for the site_