### PR TITLE
Feature/accquire eliminationorder

### DIFF
--- a/app/utils/wikiScraping.tsx
+++ b/app/utils/wikiScraping.tsx
@@ -53,7 +53,7 @@ function getFullTeamStatus(item: any): string {
     return row.lastElementChild.textContent
 }
 
-function getIsParticipating(teamStatusFull: string): bool {
+function getIsParticipating(teamStatusFull: string): boolean {
 
     var teamStatusSimple = teamStatusFull.trim().split(" ")[0]
 

--- a/app/utils/wikiScraping.tsx
+++ b/app/utils/wikiScraping.tsx
@@ -28,6 +28,9 @@ export async function getData() {
 
             const fullTeamStatus = getFullTeamStatus(domQuery[i])
             team.isParticipating = getIsParticipating(fullTeamStatus)
+            if (!team.isParticipating) {
+                team.eliminationOrder = getEliminationOrder(fullTeamStatus)
+            }
         } else {
             final.push(team)
             team = {teamName: "", isParticipating: true, eliminationOrder: 0}
@@ -55,5 +58,13 @@ function getIsParticipating(teamStatusFull: string): bool {
     var teamStatusSimple = teamStatusFull.trim().split(" ")[0]
 
     return teamStatusSimple === "Eliminated" ? false : true
+}
+
+function getEliminationOrder(teamStatusFull: string): number {
+
+    const teamOrderSection = teamStatusFull.trim().split(" ")[1]
+    const teamOrderString = teamOrderSection[0]
+
+    return Number(teamOrderString)
 }
 

--- a/app/utils/wikiScraping.tsx
+++ b/app/utils/wikiScraping.tsx
@@ -1,4 +1,3 @@
-
 import { JSDOM } from 'jsdom'
 
 export const wikiUrl = "https://en.wikipedia.org/wiki/The_Amazing_Race_35"
@@ -36,6 +35,19 @@ export async function getData() {
     return { props: { runners: final } }
 }
 
+function getFullTeamStatus(item: any): string {
+
+    var row = null
+    if (item !== null &&
+        item.parentElement !== null &&
+        item.parentElement.parentElement !== null &&
+        item.parentElement.parentElement.parentElement !== null &&
+        item.parentElement.parentElement.parentElement.parentElement !== null) {
+            row = item.parentElement.parentElement.parentElement.parentElement
+    }
+    return row.lastElementChild.textContent
+}
+
 function getIsParticipating(item: any) {
 
     var row = null
@@ -51,3 +63,4 @@ function getIsParticipating(item: any) {
 
     return teamStatusSimple === "Eliminated" ? false : true
 }
+

--- a/app/utils/wikiScraping.tsx
+++ b/app/utils/wikiScraping.tsx
@@ -11,7 +11,8 @@ export async function getData() {
 
     // Build data model
     const final = []
-    var team = {teamName: "", isParticipating: true}
+    // may want to start with eliminationOrder = team.length, but we don't have that right now
+    var team = {teamName: "", isParticipating: true, eliminationOrder: 0}
     for (var i = 0; i < domQuery.length; i++) {
         var contestantFullName = domQuery[i].textContent
         var contestantNames = null
@@ -29,7 +30,7 @@ export async function getData() {
             team.isParticipating = getIsParticipating(fullTeamStatus)
         } else {
             final.push(team)
-            team = {teamName: "", isParticipating: true}
+            team = {teamName: "", isParticipating: true, eliminationOrder: 0}
         }
     }
 

--- a/app/utils/wikiScraping.tsx
+++ b/app/utils/wikiScraping.tsx
@@ -25,7 +25,8 @@ export async function getData() {
         if (i % 2 == 0) {
             team.teamName += " & "
 
-            team.isParticipating = getIsParticipating(domQuery[i])
+            const fullTeamStatus = getFullTeamStatus(domQuery[i])
+            team.isParticipating = getIsParticipating(fullTeamStatus)
         } else {
             final.push(team)
             team = {teamName: "", isParticipating: true}
@@ -48,9 +49,8 @@ function getFullTeamStatus(item: any): string {
     return row.lastElementChild.textContent
 }
 
-function getIsParticipating(item: any) {
+function getIsParticipating(teamStatusFull: string): bool {
 
-    var teamStatusFull = getFullTeamStatus(item)
     var teamStatusSimple = teamStatusFull.trim().split(" ")[0]
 
     return teamStatusSimple === "Eliminated" ? false : true

--- a/app/utils/wikiScraping.tsx
+++ b/app/utils/wikiScraping.tsx
@@ -50,15 +50,7 @@ function getFullTeamStatus(item: any): string {
 
 function getIsParticipating(item: any) {
 
-    var row = null
-    if (item !== null &&
-        item.parentElement !== null &&
-        item.parentElement.parentElement !== null &&
-        item.parentElement.parentElement.parentElement !== null &&
-        item.parentElement.parentElement.parentElement.parentElement !== null) {
-            row = item.parentElement.parentElement.parentElement.parentElement
-    }
-    var teamStatusFull = row.lastElementChild.textContent
+    var teamStatusFull = getFullTeamStatus(item)
     var teamStatusSimple = teamStatusFull.trim().split(" ")[0]
 
     return teamStatusSimple === "Eliminated" ? false : true


### PR DESCRIPTION
Most of the changes here are pretty self explanitory, but just to make sure they get listed for an at a glance look
- Add an `eliminationOrder` prop
- Default the `eliminationOrder` to 0 (would like to make it teams.length, but we don't have that value upon initialization, may be worth trying to clean up after)
- Create a few helpers to that I can get a bit more typing
- One function to get the fullTeamStatus
- Two more helpers to get `isParticipating` and another to get `eliminationOrder`