### PR TITLE
Feature/add perfect scoring

### DIFF
--- a/app/scoring/page.tsx
+++ b/app/scoring/page.tsx
@@ -36,8 +36,8 @@ export default async function Scoring() {
             <h1 className="text-2xl text-center">Current Scoring for {currentSelectedContestant}</h1>
             <br/>
             <div className="text-center">
-                {roundScores.map((s,roundNumber) => {
-                    grandTotal += s
+                {roundScores.map((score, roundNumber) => {
+                    grandTotal += score
                     currentWeek++
 
                     return (<Fragment key={"round details"+roundNumber}>
@@ -50,7 +50,7 @@ export default async function Scoring() {
                             </Fragment>)
                         })}
                         <br/>
-                        <p key={"weekTotal"+roundNumber}className="text-center">Weekly Total: {s}</p>
+                        <p key={"weekTotal"+roundNumber}className="text-center">Weekly Total: {score}</p>
                         <p key={"grandTotal"+roundNumber}className="text-center">Grand Total: {grandTotal}</p>
                         <br/>
                         <br/>

--- a/app/scoring/page.tsx
+++ b/app/scoring/page.tsx
@@ -43,11 +43,11 @@ export default async function Scoring() {
                     return (<Fragment key={"round details"+roundNumber}>
                         <h2 key={"weekHeader"+roundNumber}className="text-xl">Week {currentWeek}</h2>
                         {reverseTeamsList.map(t => {
-                            return (<>
-                                <p key={t.teamName}>
+                            return (<Fragment key={"teamStanding"+t.teamName+roundNumber}>
+                                <p key={t.teamName+roundNumber}>
                                     {t.eliminationOrder === 0 || currentWeek < t.eliminationOrder ? t.teamName : <s>{t.teamName}</s>}
                                 </p>
-                            </>)
+                            </Fragment>)
                         })}
                         <br/>
                         <p key={"weekTotal"+roundNumber}className="text-center">Weekly Total: {s}</p>

--- a/app/scoring/page.tsx
+++ b/app/scoring/page.tsx
@@ -9,21 +9,21 @@ export default async function Scoring() {
     const currentSelectedContestant = "Jacob"
 
     const numberOfRounds = pageData.props.runners.reduce(
-        (acc, x) => {
+        (acc: number, x: ITeam) => {
             return x.eliminationOrder > acc ? x.eliminationOrder : acc
         }, 0)
 
     const roundScores = []
     for(let i = 1; i <= numberOfRounds; i++) {
         const roundScore = pageData.props.runners.reduce(
-            (acc, x) => {
+            (acc: number, x: ITeam) => {
                 return x.eliminationOrder === 0 || x.eliminationOrder > i ? acc + 10 : acc
             }, 0)
         roundScores.push(roundScore)
     }
 
     const weeklyScore = pageData.props.runners.reduce(
-        (acc, x) => {
+        (acc: number, x: ITeam) => {
             return x.isParticipating ? acc + 10 : acc
         }, 0)
 

--- a/app/scoring/page.tsx
+++ b/app/scoring/page.tsx
@@ -1,5 +1,15 @@
-export default function Scoring() {
-    var currentSelectedContestant = "Jacob"
+import { getData, wikiUrl } from "../utils/wikiScraping"
+
+export default async function Scoring() {
+
+    const wikiData = await getData()
+
+    const currentSelectedContestant = "Jacob"
+
+    const weeklyScore = wikiData.props.runners.reduce(
+        (acc, x) => {
+            return x.isParticipating ? acc + 10 : acc
+        }, 0)
 
     return (
         <div>
@@ -14,6 +24,8 @@ export default function Scoring() {
                   </>)
                 })}
             </div>
+            <br/>
+            <p className="text-center">Weekly Total: {weeklyScore}</p>
         </div>
     )
 }

--- a/app/scoring/page.tsx
+++ b/app/scoring/page.tsx
@@ -35,6 +35,7 @@ export default async function Scoring() {
                 {roundScores.map(s => {
                     currentWeek++
                     return (<>
+                        <h2 className="text-xl">Week {currentWeek}</h2>
                         {reverseTeamsList.map(t => {
                             return (<>
                                 <p key={t.teamName}>

--- a/app/scoring/page.tsx
+++ b/app/scoring/page.tsx
@@ -26,6 +26,7 @@ export default async function Scoring() {
         }, 0)
 
     const reverseTeamsList = [...wikiData.props.runners].reverse()
+    let grandTotal = 0
     let currentWeek = 0
     return (
         <div>
@@ -33,7 +34,9 @@ export default async function Scoring() {
             <br/>
             <div className="text-center">
                 {roundScores.map(s => {
+                    grandTotal += s
                     currentWeek++
+
                     return (<>
                         <h2 className="text-xl">Week {currentWeek}</h2>
                         {reverseTeamsList.map(t => {
@@ -45,6 +48,7 @@ export default async function Scoring() {
                         })}
                         <br/>
                         <p className="text-center">Weekly Total: {s}</p>
+                        <p className="text-center">Grand Total: {grandTotal}</p>
                         <br/>
                         <br/>
                     </>)

--- a/app/scoring/page.tsx
+++ b/app/scoring/page.tsx
@@ -6,6 +6,20 @@ export default async function Scoring() {
 
     const currentSelectedContestant = "Jacob"
 
+    const numberOfRounds = wikiData.props.runners.reduce(
+        (acc, x) => {
+            return x.eliminationOrder > acc ? x.eliminationOrder : acc
+        }, 0)
+
+    const roundScores = []
+    for(let i = 1; i <= numberOfRounds; i++) {
+        const roundScore = wikiData.props.runners.reduce(
+            (acc, x) => {
+                return x.eliminationOrder === 0 || x.eliminationOrder > i ? acc + 10 : acc
+            }, 0)
+        roundScores.push(roundScore)
+    }
+
     const weeklyScore = wikiData.props.runners.reduce(
         (acc, x) => {
             return x.isParticipating ? acc + 10 : acc

--- a/app/scoring/page.tsx
+++ b/app/scoring/page.tsx
@@ -1,3 +1,4 @@
+import { Fragment } from 'react'
 import { getTeamList, ITeam } from "../utils/wikiQuery"
 import { wikiUrl, getWikipediaContestantData } from "../utils/wikiFetch"
 
@@ -39,8 +40,8 @@ export default async function Scoring() {
                     grandTotal += s
                     currentWeek++
 
-                    return (<>
-                        <h2 className="text-xl">Week {currentWeek}</h2>
+                    return (<Fragment key={"round details"+roundNumber}>
+                        <h2 key={"weekHeader"+roundNumber}className="text-xl">Week {currentWeek}</h2>
                         {reverseTeamsList.map(t => {
                             return (<>
                                 <p key={t.teamName}>
@@ -49,11 +50,11 @@ export default async function Scoring() {
                             </>)
                         })}
                         <br/>
-                        <p className="text-center">Weekly Total: {s}</p>
-                        <p className="text-center">Grand Total: {grandTotal}</p>
+                        <p key={"weekTotal"+roundNumber}className="text-center">Weekly Total: {s}</p>
+                        <p key={"grandTotal"+roundNumber}className="text-center">Grand Total: {grandTotal}</p>
                         <br/>
                         <br/>
-                    </>)
+                    </Fragment>)
                 })}
             </div>
         </div>

--- a/app/scoring/page.tsx
+++ b/app/scoring/page.tsx
@@ -4,6 +4,16 @@ export default function Scoring() {
     return (
         <div>
             <h1 className="text-2xl text-center">Current Scoring for {currentSelectedContestant}</h1>
+            <br/>
+            <div className="text-center">
+                {wikiData.props.runners.map(t => {
+                  return (<>
+                      <p key={t.teamName}>
+                          {t.isParticipating ? t.teamName : <s>{t.teamName}</s>}
+                      </p>
+                  </>)
+                })}
+            </div>
         </div>
     )
 }

--- a/app/scoring/page.tsx
+++ b/app/scoring/page.tsx
@@ -37,9 +37,13 @@ export default async function Scoring() {
                       </p>
                   </>)
                 })}
+                <br/>
+                {roundScores.map(s => {
+                    return (<>
+                        <p className="text-center">Weekly Total: {s}</p>
+                    </>)
+                })}
             </div>
-            <br/>
-            <p className="text-center">Weekly Total: {weeklyScore}</p>
         </div>
     )
 }

--- a/app/scoring/page.tsx
+++ b/app/scoring/page.tsx
@@ -41,6 +41,8 @@ export default async function Scoring() {
                         })}
                         <br/>
                         <p className="text-center">Weekly Total: {s}</p>
+                        <br/>
+                        <br/>
                     </>)
                 })}
             </div>

--- a/app/scoring/page.tsx
+++ b/app/scoring/page.tsx
@@ -25,6 +25,7 @@ export default async function Scoring() {
             return x.isParticipating ? acc + 10 : acc
         }, 0)
 
+    const reverseTeamsList = [...wikiData.props.runners].reverse()
     return (
         <div>
             <h1 className="text-2xl text-center">Current Scoring for {currentSelectedContestant}</h1>
@@ -32,7 +33,7 @@ export default async function Scoring() {
             <div className="text-center">
                 {roundScores.map(s => {
                     return (<>
-                        {wikiData.props.runners.map(t => {
+                        {reverseTeamsList.map(t => {
                             return (<>
                                 <p key={t.teamName}>
                                     {t.isParticipating ? t.teamName : <s>{t.teamName}</s>}

--- a/app/scoring/page.tsx
+++ b/app/scoring/page.tsx
@@ -30,16 +30,16 @@ export default async function Scoring() {
             <h1 className="text-2xl text-center">Current Scoring for {currentSelectedContestant}</h1>
             <br/>
             <div className="text-center">
-                {wikiData.props.runners.map(t => {
-                  return (<>
-                      <p key={t.teamName}>
-                          {t.isParticipating ? t.teamName : <s>{t.teamName}</s>}
-                      </p>
-                  </>)
-                })}
-                <br/>
                 {roundScores.map(s => {
                     return (<>
+                        {wikiData.props.runners.map(t => {
+                            return (<>
+                                <p key={t.teamName}>
+                                    {t.isParticipating ? t.teamName : <s>{t.teamName}</s>}
+                                </p>
+                            </>)
+                        })}
+                        <br/>
                         <p className="text-center">Weekly Total: {s}</p>
                     </>)
                 })}

--- a/app/scoring/page.tsx
+++ b/app/scoring/page.tsx
@@ -1,31 +1,33 @@
-import { getContestantList, wikiUrl } from "../utils/wikiQuery"
+import { getTeamList, ITeam } from "../utils/wikiQuery"
+import { wikiUrl, getWikipediaContestantData } from "../utils/wikiFetch"
 
 export default async function Scoring() {
 
-    const wikiData = await getContestantList()
+    const wikiContestants = await getWikipediaContestantData()
+    const pageData = getTeamList(wikiContestants)
 
     const currentSelectedContestant = "Jacob"
 
-    const numberOfRounds = wikiData.props.runners.reduce(
+    const numberOfRounds = pageData.props.runners.reduce(
         (acc, x) => {
             return x.eliminationOrder > acc ? x.eliminationOrder : acc
         }, 0)
 
     const roundScores = []
     for(let i = 1; i <= numberOfRounds; i++) {
-        const roundScore = wikiData.props.runners.reduce(
+        const roundScore = pageData.props.runners.reduce(
             (acc, x) => {
                 return x.eliminationOrder === 0 || x.eliminationOrder > i ? acc + 10 : acc
             }, 0)
         roundScores.push(roundScore)
     }
 
-    const weeklyScore = wikiData.props.runners.reduce(
+    const weeklyScore = pageData.props.runners.reduce(
         (acc, x) => {
             return x.isParticipating ? acc + 10 : acc
         }, 0)
 
-    const reverseTeamsList = [...wikiData.props.runners].reverse()
+    const reverseTeamsList = [...pageData.props.runners].reverse()
     let grandTotal = 0
     let currentWeek = 0
     return (

--- a/app/scoring/page.tsx
+++ b/app/scoring/page.tsx
@@ -26,17 +26,19 @@ export default async function Scoring() {
         }, 0)
 
     const reverseTeamsList = [...wikiData.props.runners].reverse()
+    let currentWeek = 0
     return (
         <div>
             <h1 className="text-2xl text-center">Current Scoring for {currentSelectedContestant}</h1>
             <br/>
             <div className="text-center">
                 {roundScores.map(s => {
+                    currentWeek++
                     return (<>
                         {reverseTeamsList.map(t => {
                             return (<>
                                 <p key={t.teamName}>
-                                    {t.isParticipating ? t.teamName : <s>{t.teamName}</s>}
+                                    {t.eliminationOrder === 0 || currentWeek < t.eliminationOrder ? t.teamName : <s>{t.teamName}</s>}
                                 </p>
                             </>)
                         })}

--- a/app/scoring/page.tsx
+++ b/app/scoring/page.tsx
@@ -35,7 +35,7 @@ export default async function Scoring() {
             <h1 className="text-2xl text-center">Current Scoring for {currentSelectedContestant}</h1>
             <br/>
             <div className="text-center">
-                {roundScores.map(s => {
+                {roundScores.map((s,roundNumber) => {
                     grandTotal += s
                     currentWeek++
 

--- a/app/scoring/page.tsx
+++ b/app/scoring/page.tsx
@@ -1,8 +1,8 @@
-import { getData, wikiUrl } from "../utils/wikiScraping"
+import { getContestantList, wikiUrl } from "../utils/wikiQuery"
 
 export default async function Scoring() {
 
-    const wikiData = await getData()
+    const wikiData = await getContestantList()
 
     const currentSelectedContestant = "Jacob"
 


### PR DESCRIPTION
Here is a change that will show a perfect scoring. This will set the stage for showing an individuals fantasy league contestant's scoring.

_Edit: I did try to see if it would make sense to set eliminationOrder to the max, but this revealed a defect based on a assumption that I was making before and that lead me to want to add some testing to help protect against strange regressions like this see #17 and in particular [this commit/change](https://github.com/jjm3x3/AmazingRaceFantasy/pull/17/commits/ee0e0b9e7c4aecf90993b4295bc4ca5100e1a17c)_ 