### PR TITLE
Feature/add testing

### DIFF
--- a/__tests__/wikiQuery.js
+++ b/__tests__/wikiQuery.js
@@ -65,19 +65,20 @@ describe('getData', () => {
         expect(result.props.runners[0].eliminationOrder).toEqual(2)
     })
 
-    it('should create team names based on merging contestants first names two at a time', () => {
+    it('should create team names based on merging contestants full names two at a time skipping the first empty one', () => {
         // Arrange
-        const firstContestantsFirstName = "Some"
-        const secondContestantsFirstName = "SomeGuys"
-        const expectedTeamName = firstContestantsFirstName + " & " + secondContestantsFirstName
+        const firstContestantsFullName = "Some" + " Guy"
+        const secondContestantsFullName = "SomeGuys" + " Brother"
+        const expectedTeamName = firstContestantsFullName + " & " + secondContestantsFullName
 
         const listOfContestants = [
+            {},
             {
-                name: firstContestantsFirstName + " Guy",
+                name: firstContestantsFullName,
                 status: "Participating"
             },
             {
-                name: secondContestantsFirstName + " Brother",
+                name: secondContestantsFullName,
                 status: "Participating"
             }
         ]

--- a/__tests__/wikiQuery.js
+++ b/__tests__/wikiQuery.js
@@ -88,4 +88,41 @@ describe('getData', () => {
 
         expect(result.props.runners[0].teamName).toEqual(expectedTeamName)
     })
+
+    it('should not give any team the eliminationOrder of the max teams if there are still Participating contestants', () => {
+        const firstContestantsFirstName = "Some"
+        const secondContestantsFirstName = "SomeGuys"
+
+        const listOfContestants = [
+            {},
+            {
+                name: firstContestantsFirstName + " Guy",
+                status: "Participating"
+            },
+            {
+                name: secondContestantsFirstName + " Brother",
+                status: "Participating"
+            },
+            {
+                name: "blah Guy",
+                status: "Participating"
+            },
+            {
+                name: "meh Brother",
+                status: "Participating"
+            },
+            {
+                name: "lost Guy",
+                status: "Eliminated 1st"
+            },
+            {
+                name: secondContestantsFirstName + "alsoLost Brother",
+                status: "Eliminated 1st"
+            }
+        ]
+
+        var result = getTeamList(listOfContestants)
+
+        expect(result.props.runners.map(x => x.eliminationOrder)).not.toContain(3)
+    })
 })

--- a/__tests__/wikiQuery.js
+++ b/__tests__/wikiQuery.js
@@ -33,7 +33,7 @@ describe('getData', () => {
                 name: firstContestantsFirstName + " Guy",
                 status: "Participating"
             },
-            {team: secondContestantsFirstName + " Brother"}
+            {name: secondContestantsFirstName + " Brother"}
         ]
 
         // Act

--- a/__tests__/wikiQuery.js
+++ b/__tests__/wikiQuery.js
@@ -64,4 +64,27 @@ describe('getData', () => {
 
         expect(result.props.runners[0].eliminationOrder).toEqual(2)
     })
+
+    it('should create team names based on merging contestants first names two at a time', () => {
+        // Arrange
+        const firstContestantsFirstName = "Some"
+        const secondContestantsFirstName = "SomeGuys"
+        const expectedTeamName = firstContestantsFirstName + " & " + secondContestantsFirstName
+
+        const listOfContestants = [
+            {
+                name: firstContestantsFirstName + " Guy",
+                status: "Participating"
+            },
+            {
+                name: secondContestantsFirstName + " Brother",
+                status: "Participating"
+            }
+        ]
+
+        // Act
+        var result = getTeamList(listOfContestants)
+
+        expect(result.props.runners[0].teamName).toEqual(expectedTeamName)
+    })
 })

--- a/app/utils/wikiFetch.tsx
+++ b/app/utils/wikiFetch.tsx
@@ -35,12 +35,18 @@ export async function getWikipediaContestantData(): Promise<IWikipediaContestant
 
         const $row =  $(element)
 
+        const name = $row.find('th span.fn').text().trim()
+        const age = $row.find('td').eq(0).text().trim()
+        const relationship = $row.find('td').eq(1).text().trim()
+        const hometown = $row.find('td').eq(2).text().trim()
+        const status = $row.find('td').eq(3).text().trim()
+
         const aContestant: IWikipediaContestantData = {
-            name: $row.find('th span.fn').text().trim(),
-            age: $row.find('td').eq(0).text().trim(),
-            relationship: $row.find('td').eq(1).text().trim(),
-            hometown: $row.find('td').eq(2).text().trim(),
-            status: $row.find('td').eq(3).text().trim()
+            name: name,
+            age: age,
+            relationship: relationship,
+            hometown: hometown,
+            status: status
         }
 
         return aContestant

--- a/app/utils/wikiQuery.tsx
+++ b/app/utils/wikiQuery.tsx
@@ -48,11 +48,5 @@ export function getTeamList(contestantData :IWikipediaContestantData[]): any {
         }
     })
 
-    contestants.map(x => {
-        if (x.eliminationOrder === 0) {
-            x.eliminationOrder = contestants.length
-        }
-    })
-
     return { props: { runners: contestants }}
 }

--- a/app/utils/wikiQuery.tsx
+++ b/app/utils/wikiQuery.tsx
@@ -48,5 +48,11 @@ export function getTeamList(contestantData :IWikipediaContestantData[]): any {
         }
     })
 
+    contestants.map(x => {
+        if (x.eliminationOrder === 0) {
+            x.eliminationOrder = contestants.length
+        }
+    })
+
     return { props: { runners: contestants }}
 }


### PR DESCRIPTION
_see note..._
Here is a PR that will add jest to unit testing to allow for better testing to make sure regressions don't come up. In order to run this in the Vercel platform the deployment command must be updated. At this time I have opted to update it from `next build` to `jest && next build` which seems to work good enough.

_note: the tests were already added in #21 but here is the addition of some more tests for code that is already written_

Now that the focus of this PR has changed every so slightly a few things to look out for.
- [x] This currently assumes that the first player/contestant in the list of contestants will be empty (@CAnthonySiever and I have already discussed adding a small filtering function to address this perhaps done in this PR)
  - _update: I started taking a look at this and it doesn't seem super difficult, but outside the scope of this which was just to add some tests on existing things so I have gone ahead and opened issue #24_
- [x] This will add a test to assert things on team names since getting a fantasy leagues contestants score is currently dependent on it (see #9) It is unclear if this is how team names should be constructed and how these two inputs (one from wiki and one from fantasy league contestant) should be matched
  - _update: Upon thinking and looking more into this I am thinking that we should proceed assuming that we will use both contestants full names with the '&' character for now and we can move further discussion into #25_ 
- [x] This PR started on the premise that if a teams eliminationOrder is initialized to the max then it will break the scoring since the scoring will be calculated on the max of all eliminationOrders which is a bit misleading week over week. The test to assert that behavior is here, but the question is that the right assertion or should it be changed.
  - _update: the short answer is "yes." Upon some outside discussion it dawned on me "what do we get my making a teams elimination order start out set to the max" and I couldn't come up with anything, so until we do I think it is fine to assume this behavior and move on, only to reevaluate if we find a good reason to._