### PR TITLE
Feature/cross out based on list position

### DIFF
--- a/__tests__/utils/teamListUtils.js
+++ b/__tests__/utils/teamListUtils.js
@@ -15,7 +15,11 @@ describe('teamListUtils shouldBeScored', () => {
         expect(result).toBeFalsy()
     })
 
-    it('should be false when the target team is in the first position or end of array and its the first round', () => {
+    it('should be false when the target team is at the end of array and its the first round', () => {
+        // Note: being at the end of the array assums that that team should he
+        //   eliminated first
+        // Note2: rounds are 0 indexed so the first round is 0
+
         // Arrange
         const aTeam = {
             isInPlay: (round) => true
@@ -29,7 +33,8 @@ describe('teamListUtils shouldBeScored', () => {
         expect(result).toBeFalsy()
     })
 
-    it('should be false when the target team is in the first position or end of array and its the second round round', () => {
+    it('should be false when the target team is at the end of array and its the second round round', () => {
+
         // Arrange
         const aTeam = {
             isInPlay: (round) => true

--- a/__tests__/utils/teamListUtils.js
+++ b/__tests__/utils/teamListUtils.js
@@ -1,0 +1,42 @@
+import { shouldBeScored } from '../../app/utils/teamListUtils'
+
+describe('teamListUtils shouldBeScored', () => {
+    it('should be false when position and round are equal', () => {
+        // Arrange
+        const aTeam = {
+            isInPlay: (round) => true
+        }
+
+        // Act
+        const result = shouldBeScored(aTeam, 0, 0)
+
+        // Assert
+        expect(result).toBeFalsy()
+    })
+
+    it('should be false when position is 1 more than the round', () => {
+        // Arrange
+        const aTeam = {
+            isInPlay: (round) => true
+        }
+
+        // Act
+        const result = shouldBeScored(aTeam, 1, 0)
+
+        // Assert
+        expect(result).toBeFalsy()
+    })
+
+    it('should be false when position is 2 more than the round', () => {
+        // Arrange
+        const aTeam = {
+            isInPlay: (round) => true
+        }
+
+        // Act
+        const result = shouldBeScored(aTeam, 2, 0)
+
+        // Assert
+        expect(result).toBeTruthy()
+    })
+})

--- a/__tests__/utils/teamListUtils.js
+++ b/__tests__/utils/teamListUtils.js
@@ -1,40 +1,57 @@
 import { shouldBeScored } from '../../app/utils/teamListUtils'
 
 describe('teamListUtils shouldBeScored', () => {
-    it('should be false when position and round are equal', () => {
+    it('should be false when there is exactly one team and we are on the first round', () => {
         // Arrange
         const aTeam = {
             isInPlay: (round) => true
         }
+        const teamList = [aTeam]
 
         // Act
-        const result = shouldBeScored(aTeam, 0, 0)
+        const result = shouldBeScored(teamList, aTeam, 0)
 
         // Assert
         expect(result).toBeFalsy()
     })
 
-    it('should be false when position is 1 more than the round', () => {
+    it('should be false when the target team is in the first position or end of array and its the first round', () => {
         // Arrange
         const aTeam = {
             isInPlay: (round) => true
         }
+        const teamList = [{}, aTeam]
 
         // Act
-        const result = shouldBeScored(aTeam, 1, 0)
+        const result = shouldBeScored(teamList, aTeam, 0)
 
         // Assert
         expect(result).toBeFalsy()
     })
 
-    it('should be false when position is 2 more than the round', () => {
+    it('should be false when the target team is in the first position or end of array and its the second round round', () => {
         // Arrange
         const aTeam = {
             isInPlay: (round) => true
         }
+        const teamList = [{}, aTeam]
 
         // Act
-        const result = shouldBeScored(aTeam, 2, 0)
+        const result = shouldBeScored(teamList, aTeam, 1)
+
+        // Assert
+        expect(result).toBeFalsy()
+    })
+
+    it('should be true when the target team is in the 2nd position or second from the end of array and its the first round', () => {
+        // Arrange
+        const aTeam = {
+            isInPlay: (round) => true
+        }
+        const teamList = [aTeam, {}]
+
+        // Act
+        const result = shouldBeScored(teamList, aTeam, 0)
 
         // Assert
         expect(result).toBeTruthy()

--- a/app/components/teamList.tsx
+++ b/app/components/teamList.tsx
@@ -7,11 +7,9 @@ export default function TeamList({ teamList, roundNumber }: { teamList: Team[], 
     
     return <div>
         {teamList.map(t => {
-            const teamPosition = teamList.length - teamList.indexOf(t)
-
             return (<Fragment key={"teamStanding"+t.teamName+roundNumber}>
                 <p key={t.teamName+roundNumber}>
-                    {shouldBeScored(t, teamPosition, roundNumber) ? t.teamName : <s>{t.teamName}</s> }
+                    {shouldBeScored(teamList, t, roundNumber) ? t.teamName : <s>{t.teamName}</s> }
                 </p>
             </Fragment>)
         })}

--- a/app/components/teamList.tsx
+++ b/app/components/teamList.tsx
@@ -1,15 +1,17 @@
 import { Fragment } from 'react'
 import Team from '../models/Team'
-
+import { shouldBeScored } from '../utils/teamListUtils'
 
 export default function TeamList({ teamList, roundNumber }: { teamList: Team[], roundNumber: number }) {
 
     
     return <div>
         {teamList.map(t => {
+            const teamPosition = teamList.length - teamList.indexOf(t)
+
             return (<Fragment key={"teamStanding"+t.teamName+roundNumber}>
                 <p key={t.teamName+roundNumber}>
-                    {t.isInPlay(roundNumber) ? t.teamName : <s>{t.teamName}</s>}
+                    {shouldBeScored(t, teamPosition, roundNumber) ? t.teamName : <s>{t.teamName}</s> }
                 </p>
             </Fragment>)
         })}

--- a/app/scoring/page.tsx
+++ b/app/scoring/page.tsx
@@ -17,19 +17,19 @@ export default async function Scoring() {
             return x.eliminationOrder > acc ? x.eliminationOrder : acc
         }, 0)
 
+    const reverseTeamsList = [...pageData.props.runners].reverse()
+
     const roundScores = []
     for(let i = 0; i < numberOfRounds; i++) {
         const roundScore = pageData.props.runners.reduce(
             (acc: number, x: Team) => {
-                const teamsReversed = [...pageData.props.runners].reverse()
-                const teamShouldBeScored = shouldBeScored(teamsReversed, x, i)
+                const teamShouldBeScored = shouldBeScored(reverseTeamsList, x, i)
 
                 return teamShouldBeScored ? acc + 10 : acc
             }, 0)
         roundScores.push(roundScore)
     }
 
-    const reverseTeamsList = [...pageData.props.runners].reverse()
     let grandTotal = 0
     return (
         <div>

--- a/app/scoring/page.tsx
+++ b/app/scoring/page.tsx
@@ -21,7 +21,8 @@ export default async function Scoring() {
     for(let i = 0; i < numberOfRounds; i++) {
         const roundScore = pageData.props.runners.reduce(
             (acc: number, x: Team) => {
-                const teamShouldBeScored = shouldBeScored(x, pageData.props.runners.indexOf(x), i)
+                const teamsReversed = [...pageData.props.runners].reverse()
+                const teamShouldBeScored = shouldBeScored(teamsReversed, x, i)
 
                 return teamShouldBeScored ? acc + 10 : acc
             }, 0)

--- a/app/scoring/page.tsx
+++ b/app/scoring/page.tsx
@@ -3,6 +3,7 @@ import { getTeamList, ITeam } from "../utils/wikiQuery"
 import { wikiUrl, getWikipediaContestantData } from "../utils/wikiFetch"
 import TeamList from '../components/teamList'
 import Team from '../models/Team'
+import { shouldBeScored } from '../utils/teamListUtils'
 
 export default async function Scoring() {
 
@@ -20,7 +21,7 @@ export default async function Scoring() {
     for(let i = 0; i < numberOfRounds; i++) {
         const roundScore = pageData.props.runners.reduce(
             (acc: number, x: Team) => {
-                const teamShouldBeScored = x.isInPlay(i)
+                const teamShouldBeScored = shouldBeScored(x, pageData.props.runners.indexOf(x), i)
 
                 return teamShouldBeScored ? acc + 10 : acc
             }, 0)

--- a/app/utils/teamListUtils.tsx
+++ b/app/utils/teamListUtils.tsx
@@ -1,8 +1,9 @@
+import Team from '../models/Team'
 
 export function shouldBeScored(team: Team, teamPosition: number, roundNumber: number): bool {
     
    const currentWeek = roundNumber+1
-   const listHasTeamBeingEliminated = teamPosition < currentWeek
+   const listHasTeamBeingEliminated = teamPosition <= currentWeek
 
    return team.isInPlay(roundNumber) && !listHasTeamBeingEliminated
 }

--- a/app/utils/teamListUtils.tsx
+++ b/app/utils/teamListUtils.tsx
@@ -1,10 +1,12 @@
 import Team from '../models/Team'
 
-export function shouldBeScored(team: Team, teamPosition: number, roundNumber: number): boolean {
-    
-   const currentWeek = roundNumber+1
-   const listHasTeamBeingEliminated = teamPosition <= currentWeek
+export function shouldBeScored(teamList: Team[], team: Team, roundNumber: number): boolean {
 
-   return team.isInPlay(roundNumber) && !listHasTeamBeingEliminated
+    const teamPosition = teamList.length - teamList.indexOf(team)
+
+    const currentWeek = roundNumber+1
+    const listHasTeamBeingEliminated = teamPosition <= currentWeek
+
+    return team.isInPlay(roundNumber) && !listHasTeamBeingEliminated
 }
 

--- a/app/utils/teamListUtils.tsx
+++ b/app/utils/teamListUtils.tsx
@@ -1,6 +1,6 @@
 import Team from '../models/Team'
 
-export function shouldBeScored(team: Team, teamPosition: number, roundNumber: number): bool {
+export function shouldBeScored(team: Team, teamPosition: number, roundNumber: number): boolean {
     
    const currentWeek = roundNumber+1
    const listHasTeamBeingEliminated = teamPosition <= currentWeek

--- a/app/utils/teamListUtils.tsx
+++ b/app/utils/teamListUtils.tsx
@@ -1,0 +1,9 @@
+
+export function shouldBeScored(team: Team, teamPosition: number, roundNumber: number): bool {
+    
+   const currentWeek = roundNumber+1
+   const listHasTeamBeingEliminated = teamPosition < currentWeek
+
+   return team.isInPlay(roundNumber) && !listHasTeamBeingEliminated
+}
+


### PR DESCRIPTION
In this PR we see how the rest of my plan starts to come together. The main feature of this PR is I have introduced a helper method which will take in a list of teams a team and a round number and determine if that team should be scored or crossed out. At first glance those two may not seem like clear opposites and you might be right, but for all intents and purposes we are going to treat them that way for now. I did find out that given how we are expecting to score this and display it tend to coincide quite nicely and for now I would like to take advantage of that.

Few things to note, in no particular order
- Could this util have gone in a class - maybe, but I decided that was overkill for now
- Round is assumed to be 0 indexed because why not all other programing things are
- `teamPosition` is 1 indexed. This could probably could change, but it's really just a side effect of how it is calculated (see next point)
- `teamPosition` is the position that the team is in starting from the right most position, this is because we want to display the list with the crossed off eliminated teams at the bottom of the list
- The name of the function is `shouldBeScored` but it is also being used to cross off and that is also this branch/PR name. Yes all that is true see PR description and (see previous PR #29 ) where I am trying to merge these two things. I think this is a decent benefit for now to have this logic merged since we then get some other behaviors for free, but I could be convinced otherwise