### PR TITLE
Feature/parse out final elimination orders

### DIFF
--- a/__tests__/wikiQuery.js
+++ b/__tests__/wikiQuery.js
@@ -109,6 +109,51 @@ describe('getData', () => {
         expect(result.props.runners[3].eliminationOrder).toEqual(expectedEliminationOrder)
     })
 
+    it('Should parse out elimination order when a team is runners-up', () => {
+        const firstContestantsFirstName = "Some"
+        const secondContestantsFirstName = "SomeGuys"
+        const expectedEliminationOrder = 3
+
+        const listOfContestants = [
+            {
+                name: "blah Guy",
+                status: "Participating"
+            },
+            {
+                name: "meh Brother",
+                status: "Participating"
+            },
+            {
+                name: "another guy",
+                status: "Participating"
+            },
+            {
+                name: "his Brother",
+                status: "Participating"
+            },
+            {
+                name: "third guy",
+                status: "Participating"
+            },
+            {
+                name: "thrids Brother",
+                status: "Participating"
+            },
+            {
+                name: firstContestantsFirstName + " Guy",
+                status: "runners-up"
+            },
+            {
+                name: secondContestantsFirstName + " Brother",
+                status: "runners-up"
+            }
+        ]
+
+        var result = getTeamList(listOfContestants)
+
+        expect(result.props.runners[3].eliminationOrder).toEqual(expectedEliminationOrder)
+    })
+
     it('should create team names based on merging contestants full names two at a time skipping the first empty one', () => {
         // Arrange
         const firstContestantsFullName = "Some" + " Guy"

--- a/__tests__/wikiQuery.js
+++ b/__tests__/wikiQuery.js
@@ -64,6 +64,51 @@ describe('getData', () => {
         expect(result.props.runners[0].eliminationOrder).toEqual(2)
     })
 
+    it('Should parse out elimination order when a team is third', () => {
+        const firstContestantsFirstName = "Some"
+        const secondContestantsFirstName = "SomeGuys"
+        const expectedEliminationOrder = 2
+
+        const listOfContestants = [
+            {
+                name: "blah Guy",
+                status: "Participating"
+            },
+            {
+                name: "meh Brother",
+                status: "Participating"
+            },
+            {
+                name: "another guy",
+                status: "Participating"
+            },
+            {
+                name: "his Brother",
+                status: "Participating"
+            },
+            {
+                name: "third guy",
+                status: "Participating"
+            },
+            {
+                name: "thrids Brother",
+                status: "Participating"
+            },
+            {
+                name: firstContestantsFirstName + " Guy",
+                status: "third"
+            },
+            {
+                name: secondContestantsFirstName + " Brother",
+                status: "third"
+            }
+        ]
+
+        var result = getTeamList(listOfContestants)
+
+        expect(result.props.runners[3].eliminationOrder).toEqual(expectedEliminationOrder)
+    })
+
     it('should create team names based on merging contestants full names two at a time skipping the first empty one', () => {
         // Arrange
         const firstContestantsFullName = "Some" + " Guy"

--- a/app/utils/wikiQuery.tsx
+++ b/app/utils/wikiQuery.tsx
@@ -31,6 +31,9 @@ export function getTeamList(contestantData :IWikipediaContestantData[]): any {
             } else if (status.toLowerCase().includes("third")) {
                 isParticipating = false
                 eliminationOrder = (contestantData.length/2) - 2
+            } else if (status.toLowerCase().includes("runners-up")) {
+                isParticipating = false
+                eliminationOrder = (contestantData.length/2) - 1
             }
 
             const contestant: Team = new Team({

--- a/app/utils/wikiQuery.tsx
+++ b/app/utils/wikiQuery.tsx
@@ -28,6 +28,9 @@ export function getTeamList(contestantData :IWikipediaContestantData[]): any {
             if (status.toLowerCase().includes('eliminated')) {
                 isParticipating = false
                 eliminationOrder = Number(status.match(/Eliminated (\d+)/i)![1])
+            } else if (status.toLowerCase().includes("third")) {
+                isParticipating = false
+                eliminationOrder = (contestantData.length/2) - 2
             }
 
             const contestant: Team = new Team({


### PR DESCRIPTION
Here is a small thing that I only realized after the season ended. The way the Wiki article is written is the teams in the finale don't get an elimination order the same way that the other teams do instead they are labeled 'Third place' and 'Runners-up'. So this will fix that to give them an elimination order so we can score the order that these teams come in.