### PR TITLE
Convert the data model and generation to be more flexible

### DIFF
--- a/app/leagueData/AmazingRace_35.tsx
+++ b/app/leagueData/AmazingRace_35.tsx
@@ -1,11 +1,24 @@
 
 // Contestant Ranking
-export const ANDREWS_RANKING = [ "Corey McArthur & Rob McArthur", "Jocelyn Chao & Victor Limary", "Liam Hykel & Yeremi Hykel", "Greg Franklin & John Franklin", "Ashlie Martin & Todd Martin", "Chelsea Day & Robbin Tomich", "Lena Franklin & Morgan Franklin", "Anna Leigh Wilson & Steve Cargile", "Garrett Smith & Joel Strasser", "Ian Todd & Joe Moskowitz", "Andrea Simpson & Malaina Hatcher", "Elizabeth Rivera & Iliana Rivera", "Alexandra Lichtor & Sheridan Lichtor" ]
-
-export const CINDYS_RANKING = [ "Jocelyn Chao & Victor Limary", "Corey McArthur & Rob McArthur", "Ian Todd & Joe Moskowitz", "Liam Hykel & Yeremi Hykel", "Ashlie Martin & Todd Martin", "Garrett Smith & Joel Strasser", "Anna Leigh Wilson & Steve Cargile", "Lena Franklin & Morgan Franklin", "Greg Franklin & John Franklin", "Andrea Simpson & Malaina Hatcher", "Chelsea Day & Robbin Tomich", "Elizabeth Rivera & Iliana Rivera", "Alexandra Lichtor & Sheridan Lichtor" ]
-
-export const JACOBS_RANKING = [ "Corey McArthur & Rob McArthur", "Jocelyn Chao & Victor Limary", "Lena Franklin & Morgan Franklin", "Greg Franklin & John Franklin", "Chelsea Day & Robbin Tomich", "Anna Leigh Wilson & Steve Cargile", "Ashlie Martin & Todd Martin", "Garrett Smith & Joel Strasser", "Ian Todd & Joe Moskowitz", "Andrea Simpson & Malaina Hatcher", "Liam Hykel & Yeremi Hykel", "Elizabeth Rivera & Iliana Rivera", "Alexandra Lichtor & Sheridan Lichtor" ]
-
-export const JIMS_RANKING = [ "Jocelyn Chao & Victor Limary", "Lena Franklin & Morgan Franklin", "Anna Leigh Wilson & Steve Cargile", "Corey McArthur & Rob McArthur", "Liam Hykel & Yeremi Hykel", "Greg Franklin & John Franklin", "Ashlie Martin & Todd Martin", "Ian Todd & Joe Moskowitz", "Andrea Simpson & Malaina Hatcher", "Chelsea Day & Robbin Tomich", "Elizabeth Rivera & Iliana Rivera", "Garrett Smith & Joel Strasser", "Alexandra Lichtor & Sheridan Lichtor" ]
-
-export const RACHELS_RANKING = [ "Ashlie Martin & Todd Martin", "Jocelyn Chao & Victor Limary", "Garrett Smith & Joel Strasser", "Lena Franklin & Morgan Franklin", "Ian Todd & Joe Moskowitz", "Corey McArthur & Rob McArthur", "Greg Franklin & John Franklin", "Liam Hykel & Yeremi Hykel", "Anna Leigh Wilson & Steve Cargile", "Andrea Simpson & Malaina Hatcher", "Chelsea Day & Robbin Tomich", "Elizabeth Rivera & Iliana Rivera", "Alexandra Lichtor & Sheridan Lichtor" ]
+export const CONTESTANT_LEAGUE_DATA = [
+    {
+        name: "Andrew",
+        ranking: [ "Corey McArthur & Rob McArthur", "Jocelyn Chao & Victor Limary", "Liam Hykel & Yeremi Hykel", "Greg Franklin & John Franklin", "Ashlie Martin & Todd Martin", "Chelsea Day & Robbin Tomich", "Lena Franklin & Morgan Franklin", "Anna Leigh Wilson & Steve Cargile", "Garrett Smith & Joel Strasser", "Ian Todd & Joe Moskowitz", "Andrea Simpson & Malaina Hatcher", "Elizabeth Rivera & Iliana Rivera", "Alexandra Lichtor & Sheridan Lichtor" ]
+    },
+    {
+        name: "Cindy",
+        ranking: [ "Jocelyn Chao & Victor Limary", "Corey McArthur & Rob McArthur", "Ian Todd & Joe Moskowitz", "Liam Hykel & Yeremi Hykel", "Ashlie Martin & Todd Martin", "Garrett Smith & Joel Strasser", "Anna Leigh Wilson & Steve Cargile", "Lena Franklin & Morgan Franklin", "Greg Franklin & John Franklin", "Andrea Simpson & Malaina Hatcher", "Chelsea Day & Robbin Tomich", "Elizabeth Rivera & Iliana Rivera", "Alexandra Lichtor & Sheridan Lichtor" ]
+    },
+    {
+        name: "Jacob",
+        ranking: [ "Corey McArthur & Rob McArthur", "Jocelyn Chao & Victor Limary", "Lena Franklin & Morgan Franklin", "Greg Franklin & John Franklin", "Chelsea Day & Robbin Tomich", "Anna Leigh Wilson & Steve Cargile", "Ashlie Martin & Todd Martin", "Garrett Smith & Joel Strasser", "Ian Todd & Joe Moskowitz", "Andrea Simpson & Malaina Hatcher", "Liam Hykel & Yeremi Hykel", "Elizabeth Rivera & Iliana Rivera", "Alexandra Lichtor & Sheridan Lichtor" ]
+    },
+    {
+        name: "Jim",
+        ranking: [ "Jocelyn Chao & Victor Limary", "Lena Franklin & Morgan Franklin", "Anna Leigh Wilson & Steve Cargile", "Corey McArthur & Rob McArthur", "Liam Hykel & Yeremi Hykel", "Greg Franklin & John Franklin", "Ashlie Martin & Todd Martin", "Ian Todd & Joe Moskowitz", "Andrea Simpson & Malaina Hatcher", "Chelsea Day & Robbin Tomich", "Elizabeth Rivera & Iliana Rivera", "Garrett Smith & Joel Strasser", "Alexandra Lichtor & Sheridan Lichtor" ]
+    },
+    {
+        name: "Rachel",
+        ranking: [ "Ashlie Martin & Todd Martin", "Jocelyn Chao & Victor Limary", "Garrett Smith & Joel Strasser", "Lena Franklin & Morgan Franklin", "Ian Todd & Joe Moskowitz", "Corey McArthur & Rob McArthur", "Greg Franklin & John Franklin", "Liam Hykel & Yeremi Hykel", "Anna Leigh Wilson & Steve Cargile", "Andrea Simpson & Malaina Hatcher", "Chelsea Day & Robbin Tomich", "Elizabeth Rivera & Iliana Rivera", "Alexandra Lichtor & Sheridan Lichtor" ]
+    }
+]

--- a/app/scoring/page.tsx
+++ b/app/scoring/page.tsx
@@ -4,7 +4,7 @@ import { WIKI_API_URL } from '../leagueConfiguration/AmazingRace_35'
 import Team from '../models/Team'
 import { shouldBeScored } from '../utils/teamListUtils'
 import ContestantRoundList from '../components/contestantRoundList'
-import { ANDREWS_RANKING, CINDYS_RANKING, JACOBS_RANKING, JIMS_RANKING, RACHELS_RANKING } from '../leagueData/AmazingRace_35'
+import { CONTESTANT_LEAGUE_DATA } from '../leagueData/AmazingRace_35'
 import ContestantSelector from '../components/contestantSelector'
 
 interface Dictionary<T> {
@@ -50,63 +50,24 @@ export default async function Scoring() {
 
     const roundScores = generateContestantRoundScores(reverseTeamsList, numberOfRounds)
 
-    const andrewsTeamList = ANDREWS_RANKING.map(x => {
-        const foundTeam = teamDictionary[Team.getKey(x)]
-        return foundTeam
-    })
+    // New New Way
+    const listOfContestantRoundLists = CONTESTANT_LEAGUE_DATA.map(contestant => {
 
-    const cindysTeamList = CINDYS_RANKING.map(x => {
-        const foundTeam = teamDictionary[Team.getKey(x)]
-        return foundTeam
-    })
+        const andrewsTeamList = contestant.ranking.map(x => {
+            const foundTeam = teamDictionary[Team.getKey(x)]
+            return foundTeam
+        })
 
-    const jacobsTeamsList = JACOBS_RANKING.map(x => {
-        const foundTeam = teamDictionary[Team.getKey(x)]
-        return foundTeam
-    })
+        const andrewsRoundScores: number[] = generateContestantRoundScores(andrewsTeamList, numberOfRounds)
 
-    const jimsTeamList = JIMS_RANKING.map(x => {
-        const foundTeam = teamDictionary[Team.getKey(x)]
-        return foundTeam
-    })
 
-    const rachelsTeamList = RACHELS_RANKING.map(x => {
-        const foundTeam = teamDictionary[Team.getKey(x)]
-        return foundTeam
-    })
 
-    const andrewsRoundScores: number[] = generateContestantRoundScores(andrewsTeamList, numberOfRounds)
-
-    const cindyRoundScores: number[] = generateContestantRoundScores(cindysTeamList, numberOfRounds)
-
-    const jacobRoundScores: number[] = generateContestantRoundScores(jacobsTeamsList, numberOfRounds)
-
-    const jimRoundScores: number[] = generateContestantRoundScores(jimsTeamList, numberOfRounds)
-
-    const rachelRoundScores: number[] = generateContestantRoundScores(rachelsTeamList, numberOfRounds)
-
-    const listOfContestantRoundLists = [
-        {
-            key: "Andrew",
+        return {
+            key: contestant.name,
             content: <ContestantRoundList perfectRoundScores={roundScores} contestantRoundScores={andrewsRoundScores} perfectTeamList={reverseTeamsList} contestantTeamList={andrewsTeamList}/>
-        },
-        {
-            key: "Cindy",
-            content: <ContestantRoundList perfectRoundScores={roundScores} contestantRoundScores={cindyRoundScores} perfectTeamList={reverseTeamsList} contestantTeamList={cindysTeamList}/>
-        },
-        {
-            key: "Jacob",
-            content: <ContestantRoundList perfectRoundScores={roundScores} contestantRoundScores={jacobRoundScores} perfectTeamList={reverseTeamsList} contestantTeamList={jacobsTeamsList}/>
-        },
-        {
-            key: "Jim",
-            content: <ContestantRoundList perfectRoundScores={roundScores} contestantRoundScores={jimRoundScores} perfectTeamList={reverseTeamsList} contestantTeamList={jimsTeamList}/>
-        },
-        {
-            key: "Rachel",
-            content: <ContestantRoundList perfectRoundScores={roundScores} contestantRoundScores={rachelRoundScores} perfectTeamList={reverseTeamsList} contestantTeamList={rachelsTeamList}/>
         }
-    ]
+
+    })
 
     return (
         <div>

--- a/app/scoring/page.tsx
+++ b/app/scoring/page.tsx
@@ -60,13 +60,10 @@ export default async function Scoring() {
 
         const contestantsRoundScores: number[] = generateContestantRoundScores(contestantsTeamList, numberOfRounds)
 
-
-
         return {
             key: contestant.name,
             content: <ContestantRoundList perfectRoundScores={roundScores} contestantRoundScores={contestantsRoundScores} perfectTeamList={reverseTeamsList} contestantTeamList={contestantsTeamList}/>
         }
-
     })
 
     return (

--- a/app/scoring/page.tsx
+++ b/app/scoring/page.tsx
@@ -53,18 +53,18 @@ export default async function Scoring() {
     // New New Way
     const listOfContestantRoundLists = CONTESTANT_LEAGUE_DATA.map(contestant => {
 
-        const andrewsTeamList = contestant.ranking.map(x => {
+        const contestantsTeamList = contestant.ranking.map(x => {
             const foundTeam = teamDictionary[Team.getKey(x)]
             return foundTeam
         })
 
-        const andrewsRoundScores: number[] = generateContestantRoundScores(andrewsTeamList, numberOfRounds)
+        const contestantsRoundScores: number[] = generateContestantRoundScores(contestantsTeamList, numberOfRounds)
 
 
 
         return {
             key: contestant.name,
-            content: <ContestantRoundList perfectRoundScores={roundScores} contestantRoundScores={andrewsRoundScores} perfectTeamList={reverseTeamsList} contestantTeamList={andrewsTeamList}/>
+            content: <ContestantRoundList perfectRoundScores={roundScores} contestantRoundScores={contestantsRoundScores} perfectTeamList={reverseTeamsList} contestantTeamList={contestantsTeamList}/>
         }
 
     })


### PR DESCRIPTION
This is a pretty simple PR which addresses the flexibility necessary to allow for any number of contestants in a league, before this adding a new contestant would be a lot of copy and pasted code, after this change one would only need to add a new contestant to the `CONTESTANT_LEAGUE_DATA` list in order to start having your score generated and available on the site.