### PR TITLE
Feature/generate contestant data

### DIFF
--- a/app/generators/contestantRoundListGenerator.tsx
+++ b/app/generators/contestantRoundListGenerator.tsx
@@ -1,6 +1,6 @@
 import { ReactNode } from 'react'
 import { getTeamList, ITeam } from "../utils/wikiQuery"
-import { wikiUrl, getWikipediaContestantData } from "../utils/wikiFetch"
+import { getWikipediaContestantData } from "../utils/wikiFetch"
 import Team from '../models/Team'
 import { shouldBeScored } from '../utils/teamListUtils'
 import ContestantRoundList from '../components/contestantRoundList'

--- a/app/generators/contestantRoundListGenerator.tsx
+++ b/app/generators/contestantRoundListGenerator.tsx
@@ -49,7 +49,7 @@ export default async function generateListOfContestantRoundLists(wikiApiUrl: str
 
     return listOfContestantLeagueData.map(contestant => {
 
-        const currentSelectedContestantTeamsList = contestant.ranking.map(x => {
+        const currentSelectedContestantTeamsList = contestant.ranking.map((x: string) => {
             const foundTeam = teamDictionary[Team.getKey(x)]
             return foundTeam
         })

--- a/app/generators/contestantRoundListGenerator.tsx
+++ b/app/generators/contestantRoundListGenerator.tsx
@@ -1,0 +1,69 @@
+import { ReactNode } from 'react'
+import { getTeamList, ITeam } from "../utils/wikiQuery"
+import { wikiUrl, getWikipediaContestantData } from "../utils/wikiFetch"
+import Team from '../models/Team'
+import { shouldBeScored } from '../utils/teamListUtils'
+import ContestantRoundList from '../components/contestantRoundList'
+
+interface Dictionary<T> {
+    [Key: string]: T;
+}
+
+function generateContestantRoundScores(contestantTeamsList: Team[], numberOfRounds: number) {
+
+    const contestantRoundScores: number[] = []
+
+    for(let i = 0; i < numberOfRounds; i++) {
+        const roundScore = contestantTeamsList.reduce(
+            (acc: number, x: Team) => {
+                const teamShouldBeScored = shouldBeScored(contestantTeamsList, x, i)
+
+                return teamShouldBeScored ? acc + 10 : acc
+            }, 0)
+        contestantRoundScores.push(roundScore)
+    }
+
+    return contestantRoundScores
+}
+
+export default async function generateListOfContestantRoundLists(wikiApiUrl: string, listOfContestantLeagueData: any[]) {
+
+    const wikiContestants = await getWikipediaContestantData(wikiApiUrl)
+    const pageData = getTeamList(wikiContestants)
+
+    const teamDictionary = pageData.props.runners.reduce((acc: Dictionary<ITeam>, t: ITeam) => {
+            acc[Team.getKey(t.teamName)] = t
+
+            return acc
+        }, {})
+
+    const numberOfRounds = pageData.props.runners.reduce(
+        (acc: number, x: ITeam) => {
+            return x.eliminationOrder > acc ? x.eliminationOrder : acc
+        }, 0)
+
+    const reverseTeamsList = [...pageData.props.runners].reverse()
+
+    const roundScores = generateContestantRoundScores(reverseTeamsList, numberOfRounds)
+
+
+    return listOfContestantLeagueData.map(contestant => {
+
+        const currentSelectedContestantTeamsList = contestant.ranking.map(x => {
+            const foundTeam = teamDictionary[Team.getKey(x)]
+            return foundTeam
+        })
+
+        const contestantRoundScores: number[] = generateContestantRoundScores(currentSelectedContestantTeamsList, numberOfRounds)
+
+        return {
+            key: contestant.name,
+            content: <ContestantRoundList
+                perfectRoundScores={roundScores}
+                contestantRoundScores={contestantRoundScores}
+                perfectTeamList={reverseTeamsList}
+                contestantTeamList={currentSelectedContestantTeamsList}
+            />
+        }
+    })
+}

--- a/app/scoring/page.tsx
+++ b/app/scoring/page.tsx
@@ -8,28 +8,6 @@ import { CONTESTANT_LEAGUE_DATA } from '../leagueData/AmazingRace_35'
 import ContestantSelector from '../components/contestantSelector'
 import generateListOfContestantRoundLists from '../generators/contestantRoundListGenerator'
 
-interface Dictionary<T> {
-    [Key: string]: T;
-}
-
-
-function generateContestantRoundScores(contestantTeamsList: Team[], numberOfRounds: number) {
-
-    const contestantRoundScores: number[] = []
-
-    for(let i = 0; i < numberOfRounds; i++) {
-        const roundScore = contestantTeamsList.reduce(
-            (acc: number, x: Team) => {
-                const teamShouldBeScored = shouldBeScored(contestantTeamsList, x, i)
-
-                return teamShouldBeScored ? acc + 10 : acc
-            }, 0)
-        contestantRoundScores.push(roundScore)
-    }
-
-    return contestantRoundScores
-}
-
 export default async function Scoring() {
 
     const listOfContestantRoundLists = await generateListOfContestantRoundLists(WIKI_API_URL, CONTESTANT_LEAGUE_DATA)

--- a/app/scoring/page.tsx
+++ b/app/scoring/page.tsx
@@ -6,6 +6,7 @@ import { shouldBeScored } from '../utils/teamListUtils'
 import ContestantRoundList from '../components/contestantRoundList'
 import { CONTESTANT_LEAGUE_DATA } from '../leagueData/AmazingRace_35'
 import ContestantSelector from '../components/contestantSelector'
+import generateListOfContestantRoundLists from '../generators/contestantRoundListGenerator'
 
 interface Dictionary<T> {
     [Key: string]: T;

--- a/app/scoring/page.tsx
+++ b/app/scoring/page.tsx
@@ -32,40 +32,7 @@ function generateContestantRoundScores(contestantTeamsList: Team[], numberOfRoun
 
 export default async function Scoring() {
 
-    const wikiContestants = await getWikipediaContestantData(WIKI_API_URL)
-    const pageData = getTeamList(wikiContestants)
-
-    const teamDictionary = pageData.props.runners.reduce((acc: Dictionary<ITeam>, t: ITeam) => {
-            acc[Team.getKey(t.teamName)] = t
-
-            return acc
-        }, {})
-
-
-    const numberOfRounds = pageData.props.runners.reduce(
-        (acc: number, x: ITeam) => {
-            return x.eliminationOrder > acc ? x.eliminationOrder : acc
-        }, 0)
-
-    const reverseTeamsList = [...pageData.props.runners].reverse()
-
-    const roundScores = generateContestantRoundScores(reverseTeamsList, numberOfRounds)
-
-    // New New Way
-    const listOfContestantRoundLists = CONTESTANT_LEAGUE_DATA.map(contestant => {
-
-        const contestantsTeamList = contestant.ranking.map(x => {
-            const foundTeam = teamDictionary[Team.getKey(x)]
-            return foundTeam
-        })
-
-        const contestantsRoundScores: number[] = generateContestantRoundScores(contestantsTeamList, numberOfRounds)
-
-        return {
-            key: contestant.name,
-            content: <ContestantRoundList perfectRoundScores={roundScores} contestantRoundScores={contestantsRoundScores} perfectTeamList={reverseTeamsList} contestantTeamList={contestantsTeamList}/>
-        }
-    })
+    const listOfContestantRoundLists = await generateListOfContestantRoundLists(WIKI_API_URL, CONTESTANT_LEAGUE_DATA)
 
     return (
         <div>

--- a/app/scoring/page.tsx
+++ b/app/scoring/page.tsx
@@ -1,9 +1,4 @@
-import { getTeamList, ITeam } from "../utils/wikiQuery"
-import { getWikipediaContestantData } from "../utils/wikiFetch"
 import { WIKI_API_URL } from '../leagueConfiguration/AmazingRace_35'
-import Team from '../models/Team'
-import { shouldBeScored } from '../utils/teamListUtils'
-import ContestantRoundList from '../components/contestantRoundList'
 import { CONTESTANT_LEAGUE_DATA } from '../leagueData/AmazingRace_35'
 import ContestantSelector from '../components/contestantSelector'
 import generateListOfContestantRoundLists from '../generators/contestantRoundListGenerator'


### PR DESCRIPTION
There isn't necessarily a lot going on in this PR, but I do feel like this concept is a big one since it will likely be how lots of other pages work, especially ones that have a lot of static content and need to be generated for every league. The idea here is a simple one. We want to have at least one scoring page for every league but the contestants and the Wikipedia data backing the scoring will change for each league. In order to re use as much of the code as possible I am extracting a lot of it here into a "generator" that way that same generator can be invoked in another scoring page for another league/season.

This should address #41 