### PR TITLE
Use anchor to find the current section number to avoid pulling bad data

### DIFF
--- a/app/leagueConfiguration/AmazingRace_35.tsx
+++ b/app/leagueConfiguration/AmazingRace_35.tsx
@@ -1,5 +1,5 @@
 export const WIKI_PAGE_URL = "https://en.wikipedia.org/wiki/The_Amazing_Race_35"
 
-export const WIKI_API_URL = "https://en.wikipedia.org/w/api.php?action=parse&format=json&page=The_Amazing_Race_35&section=7&formatversion=2"
+export const WIKI_API_URL = "https://en.wikipedia.org/w/api.php?action=parse&format=json&page=The_Amazing_Race_35"
 
 export const GOOGLE_SHEET_URL = "https://docs.google.com/spreadsheets/d/1ei7I7ER9uHwAODnLGyNRhUA7ppYQLuwox8cYRgypLm8/edit?usp=sharing"

--- a/app/leagueConfiguration/AmazingRace_36.tsx
+++ b/app/leagueConfiguration/AmazingRace_36.tsx
@@ -1,5 +1,5 @@
 
-export const WIKI_API_URL = "https://en.wikipedia.org/w/api.php?action=parse&format=json&page=The_Amazing_Race_36&section=7&formatversion=2"
+export const WIKI_API_URL = "https://en.wikipedia.org/w/api.php?action=parse&format=json&page=The_Amazing_Race_36"
 
 export const WIKI_PAGE_URL = "https://en.wikipedia.org/wiki/The_Amazing_Race_36"
 


### PR DESCRIPTION
As the title implies, this adds another moving part to the pulling of data, but it seems warranted since the section number from Wikipedia that we're looking to pull from is subject to change. The anchor seems to be a bit more stable and even consistent across different seasons.

I would suggest playing with it a bit since it's fun to go around the different seasons just by changing the 35 in `WIKI_API_URL` to 3 and so on in a dev environment as this might inspire other changes and features elsewhere 😁

Edit: I guess this also needs a reference to this issue since it is the final part of resolving it #5 😅 
