### PR TITLE
Feature/add cumulative rounds

### DIFF
--- a/__tests__/models/LeagueStanding.js
+++ b/__tests__/models/LeagueStanding.js
@@ -118,3 +118,33 @@ describe("generateContestantRoundScores", () => {
         expect(result[1].contestantRoundData[0].totalScore).toBe(30)
     })
 })
+
+describe("addContestantRoundScores", () => {
+    it("Should add multiple contestants to one rounds contestantRoundData per time add is called", () => {
+        // Arrange
+        let exampleTeam = new Team({teamName: "name1_1 & name1_2", isParticipating: true, eliminationOrder: 0})
+        let exampleTeam2 = new Team({teamName: "name2_1 & name2_2", isParticipating: true, eliminationOrder: 0})
+        let exampleTeam3 = new Team({teamName: "name2_1 & name2_2", isParticipating: true, eliminationOrder: 0})
+
+        const teamList = [exampleTeam, exampleTeam2, exampleTeam3]
+        const rounds = 1
+        const expectedContestantName1 = "contestant1"
+        const expectedContestantName2 = "contestant2"
+        const sut = new LeagueStanding()
+
+        // Act
+        sut.addContestantRoundScores(teamList, rounds, expectedContestantName1)
+        sut.addContestantRoundScores(teamList, rounds, expectedContestantName2)
+
+        // Assert
+        expect(sut).not.toBeNull()
+        expect(sut.rouds).not.toBeNull()
+        expect(sut.rounds.length).toBe(1)
+        expect(sut.rounds[0]).not.toBeNull()
+        expect(sut.rounds[0].contestantRoundData).not.toBeNull()
+        expect(sut.rounds[0].contestantRoundData.length).toBe(2)
+        const resultingContestantRoundData =  sut.rounds[0].contestantRoundData
+        expect(resultingContestantRoundData[0].name).toBe(expectedContestantName1)
+        expect(resultingContestantRoundData[1].name).toBe(expectedContestantName2)
+    })
+})

--- a/app/models/LeagueStanding.tsx
+++ b/app/models/LeagueStanding.tsx
@@ -9,7 +9,7 @@ export default class LeagueStanding {
         this.rounds = []
     }
 
-    addContestantRoundScores(contestantTeamsList: Team[], numberOfRounds: number, contestantName: string) {
+    addContestantRoundScores(contestantTeamsList: Team[], numberOfRounds: number, contestantName: string): void {
 
         let grandTotal = 0
         for(let i = 0; i < numberOfRounds; i++) {
@@ -45,7 +45,7 @@ export default class LeagueStanding {
     }
 
 
-    static generateContestantRoundScores(contestantTeamsList: Team[], numberOfRounds: number, contestantName: string) {
+    static generateContestantRoundScores(contestantTeamsList: Team[], numberOfRounds: number, contestantName: string): IRound[] {
 
         const result = new LeagueStanding()
         result.addContestantRoundScores(contestantTeamsList, numberOfRounds, contestantName)

--- a/app/models/LeagueStanding.tsx
+++ b/app/models/LeagueStanding.tsx
@@ -1,8 +1,9 @@
-import Team from '../models/Team'
+import IRound from './IRound'
+import Team from './Team'
 import { shouldBeScored } from '../utils/teamListUtils'
-import IRound from '../models/IRound'
 
 export default class LeagueStanding {
+    rounds: IRound[]
     
     static generateContestantRoundScores(contestantTeamsList: Team[], numberOfRounds: number, contestantName: string) {
 

--- a/app/models/LeagueStanding.tsx
+++ b/app/models/LeagueStanding.tsx
@@ -8,11 +8,9 @@ export default class LeagueStanding {
     constructor() {
         this.rounds = []
     }
-    
-    static generateContestantRoundScores(contestantTeamsList: Team[], numberOfRounds: number, contestantName: string) {
 
-        const contestantRoundScores: IRound[] = []
-    
+    addContestantRoundScores(contestantTeamsList: Team[], numberOfRounds: number, contestantName: string) {
+
         let grandTotal = 0
         for(let i = 0; i < numberOfRounds; i++) {
             const roundScore = contestantTeamsList.reduce(
@@ -22,7 +20,7 @@ export default class LeagueStanding {
                     return teamShouldBeScored ? acc + 10 : acc
                 }, 0)
             grandTotal += roundScore
-            contestantRoundScores.push({
+            this.rounds.push({
                 round: i,
                 contestantRoundData:[{
                     name: contestantName,
@@ -31,8 +29,14 @@ export default class LeagueStanding {
                 }]
             })
         }
-    
-        return contestantRoundScores
+    }
+
+    static generateContestantRoundScores(contestantTeamsList: Team[], numberOfRounds: number, contestantName: string) {
+
+        const result = new LeagueStanding()
+        result.addContestantRoundScores(contestantTeamsList, numberOfRounds, contestantName)
+
+        return result.rounds
     }
 
 } 

--- a/app/models/LeagueStanding.tsx
+++ b/app/models/LeagueStanding.tsx
@@ -19,17 +19,31 @@ export default class LeagueStanding {
     
                     return teamShouldBeScored ? acc + 10 : acc
                 }, 0)
+
             grandTotal += roundScore
-            this.rounds.push({
-                round: i,
-                contestantRoundData:[{
+
+            if (this.rounds.length > i) {
+                const currentRound = this.rounds[i]
+                currentRound.contestantRoundData.push({
                     name: contestantName,
                     roundScore: roundScore,
                     totalScore: grandTotal
-                }]
-            })
+                })
+            }
+            else {
+                this.rounds.push({
+                    round:i,
+                    contestantRoundData: [{
+                        name: contestantName,
+                        roundScore: roundScore,
+                        totalScore: grandTotal
+                    }]
+                })
+            }
+
         }
     }
+
 
     static generateContestantRoundScores(contestantTeamsList: Team[], numberOfRounds: number, contestantName: string) {
 

--- a/app/models/LeagueStanding.tsx
+++ b/app/models/LeagueStanding.tsx
@@ -38,5 +38,5 @@ export default class LeagueStanding {
 
         return result.rounds
     }
-
 } 
+

--- a/app/models/LeagueStanding.tsx
+++ b/app/models/LeagueStanding.tsx
@@ -4,6 +4,10 @@ import { shouldBeScored } from '../utils/teamListUtils'
 
 export default class LeagueStanding {
     rounds: IRound[]
+
+    constructor() {
+        this.rounds = []
+    }
     
     static generateContestantRoundScores(contestantTeamsList: Team[], numberOfRounds: number, contestantName: string) {
 


### PR DESCRIPTION
So in order to get a contestant ranking page we need to get every contestants round score merge all together where we can see all contestants score for a round all at the same time. So this method allows us to generate all the contestants round scores by adding them to the model over time.