### PR TITLE
123 create scoring page

### DIFF
--- a/__tests__/generators/contestantRoundListGenerator.tsx
+++ b/__tests__/generators/contestantRoundListGenerator.tsx
@@ -1,0 +1,15 @@
+import { getNumberOfRounds } from '../../app/generators/contestantRoundListGenerator'
+
+describe("getNumberOfRounds", () => {
+    it("should not ever return Number.MAX_VALUE", () => {
+
+        //Arrange
+        const teamList = [{eliminationOrder: 1}, {eliminationOrder:2}, {eliminationOrder: Number.MAX_VALUE}]
+
+        // Act
+        const result = getNumberOfRounds(teamList)
+        
+        // Assert
+        expect(result).not.toBe(Number.MAX_VALUE)
+    })
+})

--- a/__tests__/generators/contestantRoundListGenerator.tsx
+++ b/__tests__/generators/contestantRoundListGenerator.tsx
@@ -8,7 +8,7 @@ describe("getNumberOfRounds", () => {
 
         // Act
         const result = getNumberOfRounds(teamList)
-        
+
         // Assert
         expect(result).not.toBe(Number.MAX_VALUE)
     })

--- a/__tests__/models/Team.js
+++ b/__tests__/models/Team.js
@@ -125,6 +125,28 @@ describe('Team static getKey', () => {
         // Assert
         expect(testResult).toBe(expectedResult)
     })
+
+    it("should return a string with no quotes when it doesn't have an &", () => {
+        // Arrange
+        var input = "firstName \"nickname\" lastName"
+
+        // Act
+        const result = Team.getKey(input)
+
+        // Assert
+        expect(result).toEqual(expect.not.stringContaining("\""))
+    })
+
+    it("should return a string with no spaces when it doesn't have an &", () => {
+        // Arrange
+        var input = "firstName lastName"
+
+        // Act
+        const result = Team.getKey(input)
+
+        // Assert
+        expect(result).toEqual(expect.not.stringContaining(" "))
+    })
 })
 
 describe("Team friendlyName", () => {

--- a/__tests__/models/Team.js
+++ b/__tests__/models/Team.js
@@ -179,4 +179,18 @@ describe("Team friendlyName", () => {
         expect(result).toContain(expectedFirstFirstName)
         expect(result).toContain(expectedSecondFirstName)
     })
+
+    it("should return the teamName as is when there is no & in the name", () => {
+        // Not a hard requrement, more just wanting to capture some default behavior
+
+        // Arrange
+        const fullName = "some long name \"with\" \"quotes\""
+        const sut = new Team({teamName: fullName})
+
+        // Act
+        const result = sut.friendlyName()
+
+        // Assert
+        expect(result).toEqual(fullName)
+    })
 })

--- a/app/generators/contestantRoundListGenerator.tsx
+++ b/app/generators/contestantRoundListGenerator.tsx
@@ -26,10 +26,7 @@ export default async function generateListOfContestantRoundLists(
             return acc
         }, {})
 
-    const numberOfRounds = pageData.props.runners.reduce(
-        (acc: number, x: ITeam) => {
-            return x.eliminationOrder > acc ? x.eliminationOrder : acc
-        }, 0)
+    const numberOfRounds = getNumberOfRounds(pageData.props.runners)
 
     const reverseTeamsList = [...pageData.props.runners].reverse()
 
@@ -58,3 +55,11 @@ export default async function generateListOfContestantRoundLists(
         }
     })
 }
+
+export function getNumberOfRounds(teams: ITeam[]): number {
+     return teams.reduce(
+        (acc: number, x: ITeam) => {
+            return x.eliminationOrder > acc ? x.eliminationOrder : acc
+        }, 0)
+}
+

--- a/app/generators/contestantRoundListGenerator.tsx
+++ b/app/generators/contestantRoundListGenerator.tsx
@@ -54,8 +54,6 @@ export default async function generateListOfContestantRoundLists(
             />
         }
     })
-
-    //return [{key:"none", content: <>Hi</>}]
 }
 
 export function getNumberOfRounds(teams: ITeam[]): number {

--- a/app/generators/contestantRoundListGenerator.tsx
+++ b/app/generators/contestantRoundListGenerator.tsx
@@ -54,12 +54,14 @@ export default async function generateListOfContestantRoundLists(
             />
         }
     })
+
+    //return [{key:"none", content: <>Hi</>}]
 }
 
 export function getNumberOfRounds(teams: ITeam[]): number {
      return teams.reduce(
         (acc: number, x: ITeam) => {
-            return x.eliminationOrder > acc ? x.eliminationOrder : acc
+            return x.eliminationOrder > acc && x.eliminationOrder !== Number.MAX_VALUE ? x.eliminationOrder : acc
         }, 0)
 }
 

--- a/app/generators/contestantRoundListGenerator.tsx
+++ b/app/generators/contestantRoundListGenerator.tsx
@@ -11,10 +11,14 @@ interface Dictionary<T> {
     [Key: string]: T;
 }
 
-export default async function generateListOfContestantRoundLists(dataFetcher: () => Promise<ITableRowData[]>, listOfContestantLeagueData: any[]) {
+export default async function generateListOfContestantRoundLists(
+    dataFetcher: () => Promise<ITableRowData[]>,
+    listOfContestantLeagueData: any[],
+    getCompetingEntityListFunction: (x: ITableRowData[]) => any = getTeamList,
+) {
 
     const wikiContestants = await dataFetcher()
-    const pageData = getTeamList(wikiContestants)
+    const pageData = getCompetingEntityListFunction(wikiContestants)
 
     const teamDictionary = pageData.props.runners.reduce((acc: Dictionary<ITeam>, t: ITeam) => {
             acc[Team.getKey(t.teamName)] = t

--- a/app/models/Team.tsx
+++ b/app/models/Team.tsx
@@ -50,19 +50,23 @@ export default class Team {
     }
 
     static getKey(teamName: string): string {
-        var seed = ""
+        if (teamName.includes("&")) {
+            var seed = ""
 
-        const names = teamName
-            .split("&")
-            .map(s => s.trim() )
+            const names = teamName
+                .split("&")
+                .map(s => s.trim() )
 
-        if (names[0][0] > names[1][0]) {
-            seed = names[1] + names[0]
+            if (names[0][0] > names[1][0]) {
+                seed = names[1] + names[0]
+            }
+            else {
+                seed = names[0] + names[1]
+            }
+            return seed
+        } else {
+            return teamName.replace(/"/g, "").replace(/ /g, "")
         }
-        else {
-            seed = names[0] + names[1]
-        }
-        return seed
     }
 }
 

--- a/app/models/Team.tsx
+++ b/app/models/Team.tsx
@@ -29,12 +29,16 @@ export default class Team {
     }
 
     friendlyName(): string {
-        const contestantNames = this.teamName.split("&")
+        if (this.teamName.includes("&")) {
+            const contestantNames = this.teamName.split("&")
 
-        const firstContestantsFirstName = this.determineFirstName(contestantNames[0].trim())
-        const secondContestantsFirstName = this.determineFirstName(contestantNames[1].trim())
+            const firstContestantsFirstName = this.determineFirstName(contestantNames[0].trim())
+            const secondContestantsFirstName = this.determineFirstName(contestantNames[1].trim())
 
-        return firstContestantsFirstName + " & " + secondContestantsFirstName
+            return firstContestantsFirstName + " & " + secondContestantsFirstName
+        } else {
+            return this.teamName
+        }
     }
 
     private determineFirstName(contestantName: string): string {


### PR DESCRIPTION
### Summary/Acceptance Criteria
This change makes the necessary changes to the scoring page and mechanism support a BigBrother league. Main changes include
- Injecting `competingEntity` "parser" (formerly `getTeamList` for Amazing race)
- Updates the `getNumberOfRounds` to omit `Number.MAX_VALUE` and a test for it
- Update `getKey` to support BB showContestant names
- Update `getFriendlyName` to just show BB showContestants full name

### Screenshots
N/A since this doesn't change any visible behavior.

## Confirm
- [x] This PR has unit tests scenarios.
- [x] This PR is correctly linked to the relevant issue or milestone.
- [x] This PR has been locally QA'd.

/assign me