### PR TITLE
Bugfix/two small buggs

### DIFF
--- a/app/generators/contestantRoundListGenerator.tsx
+++ b/app/generators/contestantRoundListGenerator.tsx
@@ -37,7 +37,8 @@ export default async function generateListOfContestantRoundLists(
     return listOfContestantLeagueData.map(contestant => {
 
         const currentSelectedContestantTeamsList = contestant.ranking.map((x: string) => {
-            const foundTeam = teamDictionary[Team.getKey(x)]
+            const teamKey = Team.getKey(x)
+            const foundTeam = teamDictionary[teamKey]
             return foundTeam
         })
 

--- a/app/leagueData/BigBrother_26.tsx
+++ b/app/leagueData/BigBrother_26.tsx
@@ -3,18 +3,18 @@
 export const CONTESTANT_LEAGUE_DATA = [
     {
         name: "Antoinette",
-        ranking: [ "Makensy Manbeck", "Brooklyn Rivera", "Quinn Martin", "Rubina Bernabe", "Tucker Des Lauriers", "Cam Sullivan-Brown", "Leah Peters", "T'kor Clottey", "Cedric Hodges", "Chelsie Baham", "Kimo Apaka", "Angela Murray", "Joseph Rodriguez", "Matt Hardeman", "Lisa Weintraub", "Kenney Kelly" ]
+        ranking: [ "Makensy Manbeck", "Brooklyn Rivera", "Quinn Martin", "Rubina Bernabe", "Tucker Des Lauriers", "Cam Sullivan-Brown", "Leah Peters", "T'kor Clottey", "Cedric Hodges", "Chelsie Baham", "Kimo Apaka", "Angela Murray", "Joseph Rodriguez", "Matt Hardeman", "Lisa Weintraub", "Kenney Kelley" ]
     },
     {
         name: "Duncan",
-        ranking: [ "Leah Peters", "Quinn Martin", "Brooklyn Rivera", "Cam Sullivan-Brown", "Makensy Manbeck", "Chelsie Baham", "T'kor Clottey", "Joseph Rodriguez", "Tucker Des Lauriers", "Rubina Bernabe", "Lisa Weintraub", "Angela Murray", "Kimo Apaka", "Matt Hardeman", "Cedric Hodges", "Kenney Kelly" ]
+        ranking: [ "Leah Peters", "Quinn Martin", "Brooklyn Rivera", "Cam Sullivan-Brown", "Makensy Manbeck", "Chelsie Baham", "T'kor Clottey", "Joseph Rodriguez", "Tucker Des Lauriers", "Rubina Bernabe", "Lisa Weintraub", "Angela Murray", "Kimo Apaka", "Matt Hardeman", "Cedric Hodges", "Kenney Kelley" ]
     },
     {
         name: "Jacob",
-        ranking: [ "Rubina Bernabe", "Quinn Martin", "Makensy Manbeck", "Cam Sullivan-Brown", "Brooklyn Rivera", "T'kor Clottey", "Matt Hardeman", "Tucker Des Lauriers", "Leah Peters", "Cedric Hodges", "Joseph Rodriguez", "Kenney Kelly", "Kimo Apaka", "Lisa Weintraub", "Angela Murray", "Chelsie Baham" ]
+        ranking: [ "Rubina Bernabe", "Quinn Martin", "Makensy Manbeck", "Cam Sullivan-Brown", "Brooklyn Rivera", "T'kor Clottey", "Matt Hardeman", "Tucker Des Lauriers", "Leah Peters", "Cedric Hodges", "Joseph Rodriguez", "Kenney Kelley", "Kimo Apaka", "Lisa Weintraub", "Angela Murray", "Chelsie Baham" ]
     },
     {
         name: "Sam",
-        ranking: [ "Rubina Bernabe", "Quinn Martin", "Leah Peters", "Angela Murray", "Makensy Manbeck", "Kenney Kelly", "Cam Sullivan-Brown", "Tucker Des Lauriers", "Brooklyn Rivera", "Lisa Weintraub", "Kimo Apaka", "Joseph Rodriguez", "Chelsie Baham", "T'kor Clottey", "Cedric Hodges", "Matt Hardeman" ]
+        ranking: [ "Rubina Bernabe", "Quinn Martin", "Leah Peters", "Angela Murray", "Makensy Manbeck", "Kenney Kelley", "Cam Sullivan-Brown", "Tucker Des Lauriers", "Brooklyn Rivera", "Lisa Weintraub", "Kimo Apaka", "Joseph Rodriguez", "Chelsie Baham", "T'kor Clottey", "Cedric Hodges", "Matt Hardeman" ]
     }
 ]

--- a/app/utils/wikiQuery.tsx
+++ b/app/utils/wikiQuery.tsx
@@ -124,7 +124,7 @@ export function getCompetingEntityList(contestantData :ITableRowData[]): any {
         // for big-brother
         else if (status.toLowerCase().includes("evicted")) {
             isParticipating = false
-            const statusMatches = status.match(/EvictedDay (\d+)/i)
+            const statusMatches = status.match(/Evicted\W*Day (\d+)/i) // TODO: should add a test for the whitespace
             eliminationOrder = Number(statusMatches![1])
         } else if (status.toLowerCase().includes("expelled")) {
             isParticipating = false

--- a/app/utils/wikiQuery.tsx
+++ b/app/utils/wikiQuery.tsx
@@ -124,7 +124,8 @@ export function getCompetingEntityList(contestantData :ITableRowData[]): any {
         // for big-brother
         else if (status.toLowerCase().includes("evicted")) {
             isParticipating = false
-            eliminationOrder = Number(status.match(/EvictedDay (\d+)/i)![1])
+            const statusMatches = status.match(/EvictedDay (\d+)/i)
+            eliminationOrder = Number(statusMatches![1])
         } else if (status.toLowerCase().includes("expelled")) {
             isParticipating = false
             eliminationOrder = Number(status.match(/ExpelledDay (\d+)/i)![1]) // covers Luke getting booted


### PR DESCRIPTION
### Summary/Acceptance Criteria
So as soon as the first elimination happened (and as a result the first scoring) it became apparent that we have a couple of bugs. In order of discovery and also in order of effect
1. The status space in the BB25 had text without a space between "Eviction" and "Day" like "EvictionDay" but now there is a white-space so we needed to update the regex which finds a match.
2. Turns out Kenny's last name was originally wrong and so it needed to get updated meaning that every contestant who already had their ranking uploaded had his last name misspelled meaning their contestantRoundListGeneration would break.

### Screenshots
N/A

## Confirm
- [ ] This PR has unit tests scenarios. (arguably this should have at least 1 new test, but I will be leaving that to #127)
- [x] This PR is correctly linked to the relevant issue or milestone.
- [x] This PR has been locally QA'd.

/assign me