### PR TITLE
138 update notice

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -15,7 +15,7 @@ export default function Home() {
             </header>
             <main>
                 <p className="site-notice">
-                    A new season of the Big Brother has just begun. If you are already expecting an invite, they should be sent out by 12AM 07-25-24. Then, you will have until the first eviction to submit your ranking.
+                    A new season of the Big Brother Under way. If you are already participating, jump in here. If you would like to participate in this league or future leagues please email inqury to xfactorleaguesite@gmail.com.
                 </p>
                 {pages.map((p: IPage) => { 
                     const keyName = p.name.toLowerCase().replaceAll(' ', '-');

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -18,7 +18,7 @@ export default function Home() {
             </header>
             <main>
                 <p className="site-notice">
-                    A new season of the Big Brother Under way. If you are already participating, jump in <Link className="standard-link" href={noticeLink}>here</Link>. If you would like to participate in this league or future leagues please email inqury to <Link className="standard-link" href="mailto:xfactorleaguesite@gmail.com">xfactorleaguesite@gmail.com</Link>.
+                    A new season of the Big Brother Under way. If you are already participating, jump in <Link className="standard-link" href={noticeLink}>here</Link>. If you would like to participate in this league or future leagues please email inquiry to <Link className="standard-link" href="mailto:xfactorleaguesite@gmail.com">xfactorleaguesite@gmail.com</Link>.
                 </p>
                 {pages.map((p: IPage) => { 
                     const keyName = p.name.toLowerCase().replaceAll(' ', '-');

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -7,6 +7,9 @@ import "./styles/homepage.scss";
 
 export default function Home() {
     const pages = getPages() || [];
+
+    const noticeLink = "/active/big-brother-26/scoring"
+
     return (
         <div>
             <header>
@@ -15,7 +18,7 @@ export default function Home() {
             </header>
             <main>
                 <p className="site-notice">
-                    A new season of the Big Brother Under way. If you are already participating, jump in here. If you would like to participate in this league or future leagues please email inqury to xfactorleaguesite@gmail.com.
+                    A new season of the Big Brother Under way. If you are already participating, jump in <Link className="standard-link" href={noticeLink}>here</Link>. If you would like to participate in this league or future leagues please email inqury to xfactorleaguesite@gmail.com.
                 </p>
                 {pages.map((p: IPage) => { 
                     const keyName = p.name.toLowerCase().replaceAll(' ', '-');

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -18,7 +18,7 @@ export default function Home() {
             </header>
             <main>
                 <p className="site-notice">
-                    A new season of the Big Brother Under way. If you are already participating, jump in <Link className="standard-link" href={noticeLink}>here</Link>. If you would like to participate in this league or future leagues please email inqury to xfactorleaguesite@gmail.com.
+                    A new season of the Big Brother Under way. If you are already participating, jump in <Link className="standard-link" href={noticeLink}>here</Link>. If you would like to participate in this league or future leagues please email inqury to <Link className="standard-link" href="mailto:xfactorleaguesite@gmail.com">xfactorleaguesite@gmail.com</Link>.
                 </p>
                 {pages.map((p: IPage) => { 
                     const keyName = p.name.toLowerCase().replaceAll(' ', '-');


### PR DESCRIPTION
### Summary/Acceptance Criteria
Exactly as its name suggests this will update the site notice which appears at the top of the page. see #138 
_TL;DR: Now that the season has started we would like the site notice to say something that reflects that_

### Screenshots
![image](https://github.com/user-attachments/assets/340ce74e-709d-4e9b-af50-6307614fddcb)

## Confirm
- [x] This PR has unit tests scenarios. (Don't think this applies N/A?)
- [x] This PR is correctly linked to the relevant issue or milestone.
- [x] This PR has been locally QA'd.

/assign me