### PR TITLE
136 the blue problem

### DIFF
--- a/__tests__/utils/wikiQuery.js
+++ b/__tests__/utils/wikiQuery.js
@@ -615,6 +615,10 @@ describe('getCompetingEntityList', () => {
 
         const listOfContestants = [
             {
+                name: "I am a winner",
+                col4: "Winner"
+            },
+            {
                 name: "evicted last",
                 col4: "EvictedDay 86"
             },
@@ -631,7 +635,7 @@ describe('getCompetingEntityList', () => {
 
         var result = getCompetingEntityList(listOfContestants)
 
-        expect(result.props.runners.length).toEqual(3)
+        expect(result.props.runners.length).toEqual(4)
         const targetContestantList = result.props.runners.filter(x => x.teamName == emptyStatusName)
         expect(targetContestantList.length).toEqual(1)
         expect(targetContestantList[0].isParticipating).toBeFalsy()

--- a/__tests__/utils/wikiQuery.js
+++ b/__tests__/utils/wikiQuery.js
@@ -641,6 +641,42 @@ describe('getCompetingEntityList', () => {
         expect(targetContestantList[0].isParticipating).toBeFalsy()
     })
 
+    it('Should only cross out names for show contestants when they have not been evicted yet', () => {
+        const emptyStatusName = "I was the first in a double eviction"
+        const amStillCompetingName = "I am still competing"
+
+        const listOfContestants = [
+            {
+                name: amStillCompetingName,
+                col4: ""
+            },
+            {
+                name: amStillCompetingName + "2",
+                col4: ""
+            },
+            {
+                name: "evicted last",
+                col4: "EvictedDay 86"
+            },
+            {
+                name: emptyStatusName,
+                col4: ""
+            },
+            {
+                name: "first evicted",
+                col4: "EvictedDay 10"
+            }
+        ]
+
+
+        var result = getCompetingEntityList(listOfContestants)
+
+        result.props.runners.forEach(x => {
+            let shouldStillBeCompeting = x.teamName.startsWith(amStillCompetingName)
+            expect(x.isParticipating).toEqual(shouldStillBeCompeting)
+        })
+    })
+
     it('should not give any competingEntity the eliminationOrder of the max competingEntities if there are still Participating entities', () => {
         const firstContestantsFirstName = "Some"
         const secondContestantsFirstName = "SomeGuys"

--- a/__tests__/utils/wikiQuery.js
+++ b/__tests__/utils/wikiQuery.js
@@ -610,7 +610,7 @@ describe('getCompetingEntityList', () => {
         expect(targetContestantList[0].eliminationOrder).toBeLessThan(targetContestantList2[0].eliminationOrder)
     })
 
-    it('Should make sure an entity with an empty status which follows an exit status ends up with eliminationOrder in the bounds of the number of contestants', () => {
+    it('Should solve the blue problem by making sure an entity with an empty status which follows an exit status ends up with eliminationOrder in the bounds of the number of contestants', () => {
         const emptyStatusName = "blah Guy"
 
         const listOfContestants = [
@@ -641,7 +641,7 @@ describe('getCompetingEntityList', () => {
         expect(targetContestantList[0].isParticipating).toBeFalsy()
     })
 
-    it('Should only cross out names for show contestants when they have not been evicted yet', () => {
+    it('Should solve the blue problem while only cross out names for show contestants when they have not been evicted yet', () => {
         const emptyStatusName = "I was the first in a double eviction"
         const amStillCompetingName = "I am still competing"
 

--- a/__tests__/utils/wikiQuery.js
+++ b/__tests__/utils/wikiQuery.js
@@ -610,6 +610,33 @@ describe('getCompetingEntityList', () => {
         expect(targetContestantList[0].eliminationOrder).toBeLessThan(targetContestantList2[0].eliminationOrder)
     })
 
+    it('Should make sure an entity with an empty status which follows an exit status ends up with eliminationOrder in the bounds of the number of contestants', () => {
+        const emptyStatusName = "blah Guy"
+
+        const listOfContestants = [
+            {
+                name: "evicted last",
+                col4: "EvictedDay 86"
+            },
+            {
+                name: emptyStatusName,
+                col4: ""
+            },
+            {
+                name: "first evicted",
+                col4: "EvictedDay 10"
+            }
+        ]
+
+
+        var result = getCompetingEntityList(listOfContestants)
+
+        expect(result.props.runners.length).toEqual(3)
+        const targetContestantList = result.props.runners.filter(x => x.teamName == emptyStatusName)
+        expect(targetContestantList.length).toEqual(1)
+        expect(targetContestantList[0].isParticipating).toBeLessThan(false)
+    })
+
     it('should not give any competingEntity the eliminationOrder of the max competingEntities if there are still Participating entities', () => {
         const firstContestantsFirstName = "Some"
         const secondContestantsFirstName = "SomeGuys"

--- a/__tests__/utils/wikiQuery.js
+++ b/__tests__/utils/wikiQuery.js
@@ -634,7 +634,7 @@ describe('getCompetingEntityList', () => {
         expect(result.props.runners.length).toEqual(3)
         const targetContestantList = result.props.runners.filter(x => x.teamName == emptyStatusName)
         expect(targetContestantList.length).toEqual(1)
-        expect(targetContestantList[0].isParticipating).toBeLessThan(false)
+        expect(targetContestantList[0].isParticipating).toBeFalsy()
     })
 
     it('should not give any competingEntity the eliminationOrder of the max competingEntities if there are still Participating entities', () => {

--- a/app/utils/wikiQuery.tsx
+++ b/app/utils/wikiQuery.tsx
@@ -149,10 +149,10 @@ export function getCompetingEntityList(contestantData :ITableRowData[]): any {
             const foundContestant = contestants[contestants.length-1]
             if (foundContestant == null) {
                 console.debug("found previous contestant to be null")
-                isParticipating = true
+                isParticipating = true // implies that this is the first contestant
             } else if (foundContestant.exitedDay === 0) {
                 console.debug("previous contestant has not exited yet")
-                isParticipating = true
+                isParticipating = true // implies all contestants before this one are still participating
             } else {
                 foundContestant.exitedDay = foundContestant.exitedDay + 0.5 // accounts for the default ordering where the person who come first was actually evicted last
             }

--- a/app/utils/wikiQuery.tsx
+++ b/app/utils/wikiQuery.tsx
@@ -144,7 +144,6 @@ export function getCompetingEntityList(contestantData :ITableRowData[]): any {
             previousExitDay = eliminationOrder
         } else if (!isWinner) {
             // if no eliminationOrder is found, set it to the previous exitDay
-            isParticipating = false // should probably be false, but when the league starts it will be true
             eliminationOrder = previousExitDay
             const foundContestant = contestants[contestants.length-1]
             if (foundContestant == null) {
@@ -154,6 +153,7 @@ export function getCompetingEntityList(contestantData :ITableRowData[]): any {
                 console.debug("previous contestant has not exited yet")
                 isParticipating = true // implies all contestants before this one are still participating
             } else {
+                isParticipating = false // is now false because we have already started to see contestants evicted
                 foundContestant.exitedDay = foundContestant.exitedDay + 0.5 // accounts for the default ordering where the person who come first was actually evicted last
             }
         }

--- a/app/utils/wikiQuery.tsx
+++ b/app/utils/wikiQuery.tsx
@@ -143,14 +143,16 @@ export function getCompetingEntityList(contestantData :ITableRowData[]): any {
             // update previousExitDay
             previousExitDay = eliminationOrder
         } else if (!isWinner) {
-            // if no eliminationOrder is found set it to the previous exitDay
-            isParticipating = true // should probably be false, but when the league starts it will be true
+            // if no eliminationOrder is found, set it to the previous exitDay
+            isParticipating = false // should probably be false, but when the league starts it will be true
             eliminationOrder = previousExitDay
             const foundContestant = contestants[contestants.length-1]
             if (foundContestant == null) {
                 console.debug("found previous contestant to be null")
+                isParticipating = true
             } else if (foundContestant.exitedDay === 0) {
                 console.debug("previous contestant has not exited yet")
+                isParticipating = true
             } else {
                 foundContestant.exitedDay = foundContestant.exitedDay + 0.5 // accounts for the default ordering where the person who come first was actually evicted last
             }


### PR DESCRIPTION
### Summary/Acceptance Criteria
I believe it is all in the ticket, but the TL;DR is that the site doesn't work for double evictions because the first evicted house guest in a double eviction doesn't get a status in the Wikipedia Article [see Leah, this season](https://en.wikipedia.org/wiki/Big_Brother_26_(American_season)#HouseGuests)

_note: this is called "The Blue Problem" because she was the first to go in a double eviction last season_

### Screenshots
Before:
![image](https://github.com/user-attachments/assets/8111ee1d-59f4-453d-92b3-bb861b855a9d)
After:
![image](https://github.com/user-attachments/assets/072a5b99-a8e1-4b33-ade4-c4c40167ab32)

## Confirm
- [x] This PR has unit tests scenarios. (2 new ones in fact)
- [x] This PR is correctly linked to the relevant issue or milestone.
- [x] This PR has been locally QA'd.

/assign me