### PR TITLE
Feature/survivor contestants

### DIFF
--- a/app/active/survivor-47/contestants/page.tsx
+++ b/app/active/survivor-47/contestants/page.tsx
@@ -1,6 +1,6 @@
 import { getCompetingEntityList, ITeam } from "../../../utils/wikiQuery"
 import { getWikipediaContestantData } from "../../../utils/wikiFetch"
-import { WIKI_API_URL, WIKI_PAGE_URL } from '../../../leagueConfiguration/BigBrother_26'
+import { WIKI_API_URL, WIKI_PAGE_URL } from '../../../leagueConfiguration/Survivor_47'
 
 export default async function Contestants() {
 

--- a/app/active/survivor-47/contestants/page.tsx
+++ b/app/active/survivor-47/contestants/page.tsx
@@ -12,7 +12,7 @@ export default async function Contestants() {
           <br/>
           <h1 className="text-2xl text-center">Contestants</h1>
           <br/>
-          <p className="text-lg text-center">{final.props.runners.length} House Guests</p>
+          <p className="text-lg text-center">{final.props.runners.length} Contestants</p>
           <br/>
           <div className="text-center">
               {final.props.runners.map((t: ITeam) => {

--- a/app/active/survivor-47/contestants/page.tsx
+++ b/app/active/survivor-47/contestants/page.tsx
@@ -4,7 +4,7 @@ import { WIKI_API_URL, WIKI_PAGE_URL } from '../../../leagueConfiguration/Surviv
 
 export default async function Contestants() {
 
-    const wikiContestants = await getWikipediaContestantData(WIKI_API_URL, "HouseGuests")
+    const wikiContestants = await getWikipediaContestantData(WIKI_API_URL, "Contestants")
     const final = getCompetingEntityList(wikiContestants)
 
     return (

--- a/app/active/survivor-47/contestants/page.tsx
+++ b/app/active/survivor-47/contestants/page.tsx
@@ -1,0 +1,35 @@
+import { getCompetingEntityList, ITeam } from "../../../utils/wikiQuery"
+import { getWikipediaContestantData } from "../../../utils/wikiFetch"
+import { WIKI_API_URL, WIKI_PAGE_URL } from '../../../leagueConfiguration/BigBrother_26'
+
+export default async function Contestants() {
+
+    const wikiContestants = await getWikipediaContestantData(WIKI_API_URL, "HouseGuests")
+    const final = getCompetingEntityList(wikiContestants)
+
+    return (
+        <div>
+          <br/>
+          <h1 className="text-2xl text-center">Contestants</h1>
+          <br/>
+          <p className="text-lg text-center">{final.props.runners.length} House Guests</p>
+          <br/>
+          <div className="text-center">
+              {final.props.runners.map((t: ITeam) => {
+                return (<>
+                    <p key={t.teamName}>
+                        {t.isParticipating ? t.teamName : <s>{t.teamName}</s>}
+                    </p>
+                </>)
+              })}
+          </div>
+          <br/>
+          <div>
+            <p>
+              Data provided by <a className="standard-link" href={WIKI_PAGE_URL} >Wikipedia</a> for this season of Big Brother
+            </p>
+          </div>
+        </div>
+    )
+}
+

--- a/app/active/survivor-47/contestants/page.tsx
+++ b/app/active/survivor-47/contestants/page.tsx
@@ -26,7 +26,7 @@ export default async function Contestants() {
           <br/>
           <div>
             <p>
-              Data provided by <a className="standard-link" href={WIKI_PAGE_URL} >Wikipedia</a> for this season of Big Brother
+              Data provided by <a className="standard-link" href={WIKI_PAGE_URL} >Wikipedia</a> for this season of Survivor
             </p>
           </div>
         </div>

--- a/app/leagueConfiguration/Survivor_47.tsx
+++ b/app/leagueConfiguration/Survivor_47.tsx
@@ -1,4 +1,4 @@
 
 export const WIKI_API_URL = "https://en.wikipedia.org/w/api.php?action=parse&format=json&page=Survivor_47"
 
-export const WIKI_PAGE_URL = "https://en.wikipedia.org/wiki/Big_Brother_26_(American_season)"
+export const WIKI_PAGE_URL = "https://en.wikipedia.org/wiki/Survivor_47"

--- a/app/leagueConfiguration/Survivor_47.tsx
+++ b/app/leagueConfiguration/Survivor_47.tsx
@@ -1,4 +1,4 @@
 
-export const WIKI_API_URL = "https://en.wikipedia.org/w/api.php?action=parse&format=json&page=Big_Brother_26_(American_season)"
+export const WIKI_API_URL = "https://en.wikipedia.org/w/api.php?action=parse&format=json&page=Survivor_47"
 
 export const WIKI_PAGE_URL = "https://en.wikipedia.org/wiki/Big_Brother_26_(American_season)"

--- a/app/leagueConfiguration/Survivor_47.tsx
+++ b/app/leagueConfiguration/Survivor_47.tsx
@@ -1,0 +1,4 @@
+
+export const WIKI_API_URL = "https://en.wikipedia.org/w/api.php?action=parse&format=json&page=Big_Brother_26_(American_season)"
+
+export const WIKI_PAGE_URL = "https://en.wikipedia.org/wiki/Big_Brother_26_(American_season)"

--- a/app/utils/pages.tsx
+++ b/app/utils/pages.tsx
@@ -14,7 +14,15 @@ export function getPages(): ILeagueLink[] {
     const currentDirFilesList = fs.readdirSync(__dirname);
     let archiveDirFilesList: string[] = []
     const currentBBLeague = "big-brother-26"
+    const currentSurvivorLeague = "survivor-47"
     const pages: ILeagueLink[] = [
+        {
+            name: 'Current (Survivor)',
+            subpages: [{
+                name: 'Contestants',
+                path: "/active/" + currentSurvivorLeague + "/contestants"
+            }]
+        },
         {
             name: 'Current (Big Brother)',
             subpages: [{

--- a/app/utils/pages.tsx
+++ b/app/utils/pages.tsx
@@ -13,17 +13,19 @@ interface IPage {
 export function getPages(): ILeagueLink[] {
     const currentDirFilesList = fs.readdirSync(__dirname);
     let archiveDirFilesList: string[] = []
-    const currentLeague = "big-brother-26"
-    const pages: ILeagueLink[] = [{
-        name: 'Current',
-        subpages: [{
-            name: 'Contestants',
-            path: "/active/" + currentLeague + "/contestants"
-        }, {
-            name: 'Scoring',
-            path: "/active/" + currentLeague + "/scoring"
-        }]
-    }];
+    const currentBBLeague = "big-brother-26"
+    const pages: ILeagueLink[] = [
+        {
+            name: 'Current (Big Brother)',
+            subpages: [{
+                name: 'Contestants',
+                path: "/active/" + currentBBLeague + "/contestants"
+            }, {
+                name: 'Scoring',
+                path: "/active/" + currentBBLeague + "/scoring"
+            }]
+        }
+    ];
 
     if (currentDirFilesList.includes("archive")) {
         archiveDirFilesList = fs.readdirSync(__dirname+"/archive")


### PR DESCRIPTION
_Notice: this is just one proposal and should still be considered a WIP_

### Summary/Acceptance Criteria
As it's name implies this will add a Contestants page for the newest season of Survivor. 

#### Points of interest
- What the home page looks like with multiple active leagues _(see attached screenshot)_. 
  - I am sure there are other ways to do this, this one seemed the most simple to me
- Since this is _yet another copied and pasted page version it might be interesting to look at just what is different from the page it was copied from _(the BB one)_ and that diff is [here](https://github.com/jjm3x3/AmazingRaceFantasy/compare/aca02efd7195f731e4f8c34e4846ab95027173e7...feature/survivor-contestants)

### Screenshots
![image](https://github.com/user-attachments/assets/a1c0630e-f7b3-4ba5-9c25-740f860da02d)

## Confirm
- [ ] This PR has unit tests scenarios.
- [x] This PR is correctly linked to the relevant issue or milestone.
- [x] This PR has been locally QA'd.

/assign me