### PR TITLE
Feature/add amazing 35 league contestants to db

### DIFF
--- a/app/leagueData/AmazingRace_35.js
+++ b/app/leagueData/AmazingRace_35.js
@@ -3,6 +3,7 @@
 const CONTESTANT_LEAGUE_DATA = [
     {
         name: "Andrew",
+        userId: "6252275B-C6AF-427B-82A6-1F4B4A2267C1",
         ranking: [ "Corey McArthur & Rob McArthur", "Jocelyn Chao & Victor Limary", "Liam Hykel & Yeremi Hykel", "Greg Franklin & John Franklin", "Ashlie Martin & Todd Martin", "Chelsea Day & Robbin Tomich", "Lena Franklin & Morgan Franklin", "Anna Leigh Wilson & Steve Cargile", "Garrett Smith & Joel Strasser", "Ian Todd & Joe Moskowitz", "Andrea Simpson & Malaina Hatcher", "Elizabeth Rivera & Iliana Rivera", "Alexandra Lichtor & Sheridan Lichtor" ]
     },
     {

--- a/app/leagueData/AmazingRace_35.js
+++ b/app/leagueData/AmazingRace_35.js
@@ -8,6 +8,7 @@ const CONTESTANT_LEAGUE_DATA = [
     },
     {
         name: "Cindy",
+        userId: "685AAAF4-97DB-4266-A0B7-E61E2C6CA22E",
         ranking: [ "Jocelyn Chao & Victor Limary", "Corey McArthur & Rob McArthur", "Ian Todd & Joe Moskowitz", "Liam Hykel & Yeremi Hykel", "Ashlie Martin & Todd Martin", "Garrett Smith & Joel Strasser", "Anna Leigh Wilson & Steve Cargile", "Lena Franklin & Morgan Franklin", "Greg Franklin & John Franklin", "Andrea Simpson & Malaina Hatcher", "Chelsea Day & Robbin Tomich", "Elizabeth Rivera & Iliana Rivera", "Alexandra Lichtor & Sheridan Lichtor" ]
     },
     {

--- a/app/leagueData/AmazingRace_35.js
+++ b/app/leagueData/AmazingRace_35.js
@@ -13,14 +13,17 @@ const CONTESTANT_LEAGUE_DATA = [
     },
     {
         name: "Jacob",
+        userId: "C7D10281-8879-4F41-929B-723EFBE4A1C4",
         ranking: [ "Corey McArthur & Rob McArthur", "Jocelyn Chao & Victor Limary", "Lena Franklin & Morgan Franklin", "Greg Franklin & John Franklin", "Chelsea Day & Robbin Tomich", "Anna Leigh Wilson & Steve Cargile", "Ashlie Martin & Todd Martin", "Garrett Smith & Joel Strasser", "Ian Todd & Joe Moskowitz", "Andrea Simpson & Malaina Hatcher", "Liam Hykel & Yeremi Hykel", "Elizabeth Rivera & Iliana Rivera", "Alexandra Lichtor & Sheridan Lichtor" ]
     },
     {
         name: "Jim",
+        userId: "CAFA7731-EC3C-4B9D-8BC6-A199B6FB86A4",
         ranking: [ "Jocelyn Chao & Victor Limary", "Lena Franklin & Morgan Franklin", "Anna Leigh Wilson & Steve Cargile", "Corey McArthur & Rob McArthur", "Liam Hykel & Yeremi Hykel", "Greg Franklin & John Franklin", "Ashlie Martin & Todd Martin", "Ian Todd & Joe Moskowitz", "Andrea Simpson & Malaina Hatcher", "Chelsea Day & Robbin Tomich", "Elizabeth Rivera & Iliana Rivera", "Garrett Smith & Joel Strasser", "Alexandra Lichtor & Sheridan Lichtor" ]
     },
     {
         name: "Rachel",
+        userId: "E3BA8CF1-0F66-4911-88D8-A9ECFEEB37A7",
         ranking: [ "Ashlie Martin & Todd Martin", "Jocelyn Chao & Victor Limary", "Garrett Smith & Joel Strasser", "Lena Franklin & Morgan Franklin", "Ian Todd & Joe Moskowitz", "Corey McArthur & Rob McArthur", "Greg Franklin & John Franklin", "Liam Hykel & Yeremi Hykel", "Anna Leigh Wilson & Steve Cargile", "Andrea Simpson & Malaina Hatcher", "Chelsea Day & Robbin Tomich", "Elizabeth Rivera & Iliana Rivera", "Alexandra Lichtor & Sheridan Lichtor" ]
     }
 ]

--- a/scripts/seedDb.mjs
+++ b/scripts/seedDb.mjs
@@ -10,6 +10,12 @@ const redis = new Redis({
     token: process.env.KV_REST_API_TOKEN
 })
 
+const userCursor = await redis.scan("0", {match: "amazing_race:35:*"})
+
+for (const aKey of userCursor[1]) { //list of keys
+    redis.del(aKey)
+}
+
 for(const user of CONTESTANT_LEAGUE_DATA) {
     if (user.userId == null) {
         console.warn(`The user named: '${user.name}'`)

--- a/scripts/seedDb.mjs
+++ b/scripts/seedDb.mjs
@@ -10,5 +10,10 @@ const redis = new Redis({
     token: process.env.KV_REST_API_TOKEN
 })
 
+for(const user of CONTESTANT_LEAGUE_DATA) {
+    console.log("Setting user '" + user.name + "'")
+
+}
+
 const userCursor = await redis.scan("0", {match: "amazing_race:35:*"})
 console.log(userCursor)

--- a/scripts/seedDb.mjs
+++ b/scripts/seedDb.mjs
@@ -11,6 +11,11 @@ const redis = new Redis({
 })
 
 for(const user of CONTESTANT_LEAGUE_DATA) {
+    if (user.userId == null) {
+        console.warn(`The user named: '${user.name}'`)
+        continue
+    }
+
     console.log("Setting user '" + user.name + "'")
 
 }

--- a/scripts/seedDb.mjs
+++ b/scripts/seedDb.mjs
@@ -18,6 +18,9 @@ for(const user of CONTESTANT_LEAGUE_DATA) {
 
     console.log("Setting user '" + user.name + "'")
 
+    const userString = JSON.stringify(user)
+
+    await redis.json.set("amazing_race:35:"+user.userId, "$", userString)
 }
 
 const userCursor = await redis.scan("0", {match: "amazing_race:35:*"})

--- a/scripts/seedDb.mjs
+++ b/scripts/seedDb.mjs
@@ -23,5 +23,5 @@ for(const user of CONTESTANT_LEAGUE_DATA) {
     await redis.json.set("amazing_race:35:"+user.userId, "$", userString)
 }
 
-const userCursor = await redis.scan("0", {match: "amazing_race:35:*"})
-console.log(userCursor)
+const fullCursor = await redis.scan("0", {match: "*"})
+console.log(fullCursor)


### PR DESCRIPTION
### Summary/Acceptance Criteria
This is a demonstration of the overall concept where for just one of the leagues we are able to wipe away all existing data and re-seed it on every execution.

### Screenshots
<img width="436" alt="image" src="https://github.com/user-attachments/assets/2854a1d1-fd89-4118-b1b9-68d67184ec60" />

## Confirm
- [x] This PR has unit tests scenarios. (n/a we are trying to go lean on this, for now)
- [x] This PR is correctly linked to the relevant issue or milestone.
- [x] This PR has been locally QA'd. (see screenshot)

/assign me