### PR TITLE
Feature/add remaining leagues to db

### DIFF
--- a/app/leagueData/AmazingRace_36.js
+++ b/app/leagueData/AmazingRace_36.js
@@ -8,10 +8,12 @@ const CONTESTANT_LEAGUE_DATA = [
     },
     {
         name: "Anita",
+        userId: "E75E9D22-C1B5-4AF9-9824-841F15080E94",
         ranking: [ "Rod Gardner & Leticia Gardner", "Ricky Rotandi & Cesar Aldrete", "Juan Villa & Shane Bilek", "Sunny Pulver & Bizzy Smith", "Derek Williams & Shelisa Williams", "Michelle Clark & Sean Clark", "Yvonne Chavez & Melissa Main", "Kishori Turner & Karishma Cordero", "Anthony Smith & Bailey Smith", "Angie Butler & Danny Butler", "Amber Craven & Vinny Cagungun", "Chris Foster & Mary Cardona-Foster", "Maya Mody & Rohan Mody"]
     },
     {
         name: "Antoinette",
+        userId: "DCC9DCDC-AE5C-4A53-AF09-23F3C957D60B",
         ranking: [ "Rod Gardner & Leticia Gardner", "Ricky Rotandi & Cesar Aldrete", "Derek Williams & Shelisa Williams", "Kishori Turner & Karishma Cordero", "Anthony Smith & Bailey Smith", "Yvonne Chavez & Melissa Main", "Sunny Pulver & Bizzy Smith", "Michelle Clark & Sean Clark", "Juan Villa & Shane Bilek", "Angie Butler & Danny Butler", "Amber Craven & Vinny Cagungun", "Chris Foster & Mary Cardona-Foster", "Maya Mody & Rohan Mody"]
     },
     {
@@ -36,6 +38,7 @@ const CONTESTANT_LEAGUE_DATA = [
     },
     {
         name: "Sam",
+        userId: "CD9F9A71-FF9C-416A-8D0D-C268A13B021F",
         ranking: ["Ricky Rotandi & Cesar Aldrete", "Rod Gardner & Leticia Gardner", "Yvonne Chavez & Melissa Main", "Derek Williams & Shelisa Williams", "Juan Villa & Shane Bilek", "Sunny Pulver & Bizzy Smith", "Amber Craven & Vinny Cagungun", "Angie Butler & Danny Butler", "Kishori Turner & Karishma Cordero", "Anthony Smith & Bailey Smith", "Michelle Clark & Sean Clark", "Chris Foster & Mary Cardona-Foster", "Maya Mody & Rohan Mody"],
         handicap: -80
     }

--- a/app/leagueData/AmazingRace_36.js
+++ b/app/leagueData/AmazingRace_36.js
@@ -3,6 +3,7 @@
 const CONTESTANT_LEAGUE_DATA = [
     {
         name: "Andrew",
+        userId: "6252275B-C6AF-427B-82A6-1F4B4A2267C1",
         ranking: [ "Juan Villa & Shane Bilek", "Rod Gardner & Leticia Gardner", "Amber Craven & Vinny Cagungun", "Ricky Rotandi & Cesar Aldrete", "Yvonne Chavez & Melissa Main", "Michelle Clark & Sean Clark", "Derek Williams & Shelisa Williams", "Anthony Smith & Bailey Smith", "Sunny Pulver & Bizzy Smith", "Angie Butler & Danny Butler", "Chris Foster & Mary Cardona-Foster", "Kishori Turner & Karishma Cordero", "Maya Mody & Rohan Mody" ]
     },
     {
@@ -15,18 +16,22 @@ const CONTESTANT_LEAGUE_DATA = [
     },
     {
         name: "Cindy",
+        userId: "685AAAF4-97DB-4266-A0B7-E61E2C6CA22E",
         ranking: [ "Juan Villa & Shane Bilek", "Ricky Rotandi & Cesar Aldrete", "Rod Gardner & Leticia Gardner", "Derek Williams & Shelisa Williams", "Kishori Turner & Karishma Cordero", "Yvonne Chavez & Melissa Main", "Michelle Clark & Sean Clark", "Sunny Pulver & Bizzy Smith", "Amber Craven & Vinny Cagungun", "Anthony Smith & Bailey Smith", "Angie Butler & Danny Butler", "Chris Foster & Mary Cardona-Foster", "Maya Mody & Rohan Mody"]
     },
     {
         name: "Jacob",
+        userId: "C7D10281-8879-4F41-929B-723EFBE4A1C4",
         ranking: [ "Rod Gardner & Leticia Gardner", "Derek Williams & Shelisa Williams", "Ricky Rotandi & Cesar Aldrete", "Anthony Smith & Bailey Smith", "Juan Villa & Shane Bilek", "Kishori Turner & Karishma Cordero", "Angie Butler & Danny Butler", "Michelle Clark & Sean Clark", "Yvonne Chavez & Melissa Main", "Amber Craven & Vinny Cagungun", "Sunny Pulver & Bizzy Smith", "Chris Foster & Mary Cardona-Foster", "Maya Mody & Rohan Mody"]
     },
     {
         name: "Jim",
+        userId: "CAFA7731-EC3C-4B9D-8BC6-A199B6FB86A4",
         ranking: [ "Ricky Rotandi & Cesar Aldrete", "Derek Williams & Shelisa Williams", "Rod Gardner & Leticia Gardner", "Michelle Clark & Sean Clark", "Juan Villa & Shane Bilek", "Chris Foster & Mary Cardona-Foster", "Sunny Pulver & Bizzy Smith", "Kishori Turner & Karishma Cordero", "Anthony Smith & Bailey Smith", "Yvonne Chavez & Melissa Main", "Amber Craven & Vinny Cagungun", "Angie Butler & Danny Butler", "Maya Mody & Rohan Mody" ]
     },
     {
         name: "Rachel",
+        userId: "E3BA8CF1-0F66-4911-88D8-A9ECFEEB37A7",
         ranking: ["Yvonne Chavez & Melissa Main", "Amber Craven & Vinny Cagungun", "Derek Williams & Shelisa Williams", "Ricky Rotandi & Cesar Aldrete", "Michelle Clark & Sean Clark", "Juan Villa & Shane Bilek", "Kishori Turner & Karishma Cordero", "Rod Gardner & Leticia Gardner", "Anthony Smith & Bailey Smith", "Sunny Pulver & Bizzy Smith", "Angie Butler & Danny Butler", "Chris Foster & Mary Cardona-Foster", "Maya Mody & Rohan Mody"]
     },
     {

--- a/app/leagueData/BigBrother_26.js
+++ b/app/leagueData/BigBrother_26.js
@@ -8,6 +8,7 @@ const CONTESTANT_LEAGUE_DATA = [
     },
     {
         name: "Duncan",
+        userId: "268C3B55-6803-436F-BE14-D30052481EAC",
         ranking: [ "Leah Peters", "Quinn Martin", "Brooklyn Rivera", "Cam Sullivan-Brown", "Makensy Manbeck", "Chelsie Baham", "T'kor Clottey", "Joseph Rodriguez", "Tucker Des Lauriers", "Rubina Bernabe", "Lisa Weintraub", "Angela Murray", "Kimo Apaka", "Matt Hardeman", "Cedric Hodges", "Kenney Kelley" ]
     },
     {
@@ -22,10 +23,12 @@ const CONTESTANT_LEAGUE_DATA = [
     },
     {
         name: "Sean",
+        userId: "EABAE0D9-0AD0-4F2F-97E3-DF22212A375F",
         ranking: [ "Cam Sullivan-Brown", "Joseph Rodriguez", "Leah Peters", "Brooklyn Rivera", "Kenney Kelley", "T'kor Clottey", "Cedric Hodges", "Matt Hardeman", "Makensy Manbeck", "Kimo Apaka", "Tucker Des Lauriers", "Quinn Martin", "Angela Murray", "Rubina Bernabe", "Lisa Weintraub", "Chelsie Baham" ]
     },
     {
         name: "Susannah",
+        userId: "89E9072C-3A9B-4360-AAD9-9331B8449BF3",
         ranking: [ "Cam Sullivan-Brown", "Kimo Apaka", "Joseph Rodriguez", "Kenney Kelley", "Brooklyn Rivera", "Lisa Weintraub", "Makensy Manbeck", "Matt Hardeman", "Tucker Des Lauriers", "Quinn Martin", "Leah Peters", "T'kor Clottey", "Rubina Bernabe", "Angela Murray", "Chelsie Baham", "Cedric Hodges" ]
     }
 ]

--- a/app/leagueData/BigBrother_26.js
+++ b/app/leagueData/BigBrother_26.js
@@ -3,6 +3,7 @@
 const CONTESTANT_LEAGUE_DATA = [
     {
         name: "Antoinette",
+        userId: "DCC9DCDC-AE5C-4A53-AF09-23F3C957D60B",
         ranking: [ "Makensy Manbeck", "Brooklyn Rivera", "Quinn Martin", "Rubina Bernabe", "Tucker Des Lauriers", "Cam Sullivan-Brown", "Leah Peters", "T'kor Clottey", "Cedric Hodges", "Chelsie Baham", "Kimo Apaka", "Angela Murray", "Joseph Rodriguez", "Matt Hardeman", "Lisa Weintraub", "Kenney Kelley" ]
     },
     {
@@ -11,10 +12,12 @@ const CONTESTANT_LEAGUE_DATA = [
     },
     {
         name: "Jacob",
+        userId: "C7D10281-8879-4F41-929B-723EFBE4A1C4",
         ranking: [ "Rubina Bernabe", "Quinn Martin", "Makensy Manbeck", "Cam Sullivan-Brown", "Brooklyn Rivera", "T'kor Clottey", "Matt Hardeman", "Tucker Des Lauriers", "Leah Peters", "Cedric Hodges", "Joseph Rodriguez", "Kenney Kelley", "Kimo Apaka", "Lisa Weintraub", "Angela Murray", "Chelsie Baham" ]
     },
     {
         name: "Sam",
+        userId: "CD9F9A71-FF9C-416A-8D0D-C268A13B021F",
         ranking: [ "Rubina Bernabe", "Quinn Martin", "Leah Peters", "Angela Murray", "Makensy Manbeck", "Kenney Kelley", "Cam Sullivan-Brown", "Tucker Des Lauriers", "Brooklyn Rivera", "Lisa Weintraub", "Kimo Apaka", "Joseph Rodriguez", "Chelsie Baham", "T'kor Clottey", "Cedric Hodges", "Matt Hardeman" ]
     },
     {

--- a/scripts/seedDb.mjs
+++ b/scripts/seedDb.mjs
@@ -35,11 +35,11 @@ async function recreateLeagueData(leagueKeyPrefix, dataRepo) {
 
     for(const user of dataRepo.CONTESTANT_LEAGUE_DATA) {
         if (user.userId == null) {
-            console.warn(`The user named: '${user.name}'`)
+            console.warn(`Cannot insert user to leage: '${leagueKeyPrefix}' with name: '${user.name}', they are missing a userId`)
             continue
         }
 
-        console.log("Setting user '" + user.name + "'")
+        console.log(`Setting user to league '${leagueKeyPrefix}' with name: '${user.name}'`)
 
         const userString = JSON.stringify(user)
 

--- a/scripts/seedDb.mjs
+++ b/scripts/seedDb.mjs
@@ -14,8 +14,16 @@ const redis = new Redis({
 await recreateLeagueData("amazing_race:35:", amazingRace35Data)
 await recreateLeagueData("amazing_race:36:", amazingRace36Data)
 
-const fullCursor = await redis.scan("0", {match: "*"})
+let fullCursor = await redis.scan("0", {match: "*"})
 console.log(fullCursor)
+
+let nextId = fullCursor[0]
+while (nextId != 0) {
+    console.log(`Fetching next scan batch with id: '${nextId}`)
+    fullCursor = await redis.scan(nextId, {match: "*"})
+    console.log(fullCursor)
+    nextId = fullCursor[0]
+}
 
 async function recreateLeagueData(leagueKeyPrefix, dataRepo) {
 

--- a/scripts/seedDb.mjs
+++ b/scripts/seedDb.mjs
@@ -1,4 +1,5 @@
 import amazingRace35Data from "../app/leagueData/AmazingRace_35.js"
+import amazingRace36Data from "../app/leagueData/AmazingRace_36.js"
 import { Redis } from "@upstash/redis"
 
 console.log("Seeding the db")
@@ -11,6 +12,7 @@ const redis = new Redis({
 })
 
 await recreateLeagueData("amazing_race:35:", amazingRace35Data)
+await recreateLeagueData("amazing_race:36:", amazingRace36Data)
 
 const fullCursor = await redis.scan("0", {match: "*"})
 console.log(fullCursor)

--- a/scripts/seedDb.mjs
+++ b/scripts/seedDb.mjs
@@ -37,7 +37,7 @@ async function recreateLeagueData(leagueKeyPrefix, dataRepo) {
 
     for(const user of dataRepo.CONTESTANT_LEAGUE_DATA) {
         if (user.userId == null) {
-            console.warn(`Cannot insert user to leage: '${leagueKeyPrefix}' with name: '${user.name}', they are missing a userId`)
+            console.warn(`Cannot insert user to league: '${leagueKeyPrefix}' with name: '${user.name}', they are missing a userId`)
             continue
         }
 

--- a/scripts/seedDb.mjs
+++ b/scripts/seedDb.mjs
@@ -1,5 +1,6 @@
 import amazingRace35Data from "../app/leagueData/AmazingRace_35.js"
 import amazingRace36Data from "../app/leagueData/AmazingRace_36.js"
+import bigBrother26Data from "../app/leagueData/BigBrother_26.js"
 import { Redis } from "@upstash/redis"
 
 console.log("Seeding the db")
@@ -13,6 +14,7 @@ const redis = new Redis({
 
 await recreateLeagueData("amazing_race:35:", amazingRace35Data)
 await recreateLeagueData("amazing_race:36:", amazingRace36Data)
+await recreateLeagueData("big_brother:26:", bigBrother26Data)
 
 let fullCursor = await redis.scan("0", {match: "*"})
 console.log(fullCursor)


### PR DESCRIPTION
### Summary/Acceptance Criteria
Exactly as it's name describes. With this PR we will now have all user data in our non prod db at least (no reason it could not be in prod, it just isn't). 

#### Other points of interest
- Added userIds for anyone who didn't have them and ported IDs for folks who did
- Also updated the final scan to be a full db scan (this is just to set this up... we can consider disabling this)
- Updated some logging in the seeding function

### Screenshots
![image](https://github.com/user-attachments/assets/f0b9ed2b-993a-471f-89c3-8b586753e201)

## Confirm
- [x] This PR has unit tests scenarios. (n/a not doing unit tests)
- [x] This PR is correctly linked to the relevant issue or milestone. 
- [x] This PR has been locally QA'd. (see screenshot)

/assign me