### PR TITLE
Feature/add prod targeting

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "test:watch": "jest --watch",
     "format": "./node_modules/.bin/eslint -c 'eslint.config.mjs' .",
     "format:fix": "./node_modules/.bin/eslint -c 'eslint.config.mjs' --fix .",
-    "seed": "node --env-file=.env.local scripts/seedDb.mjs"
+    "seed:dev": "node --env-file=.env.development.local scripts/seedDb.mjs",
+    "seed:prod": "node --env-file=.env.production.local scripts/seedDb.mjs"
   },
   "engines": {
     "node": "^20.9.0"

--- a/scripts/seedDb.mjs
+++ b/scripts/seedDb.mjs
@@ -5,12 +5,15 @@ import { Redis } from "@upstash/redis"
 
 console.log("Seeding the db");
 
-console.log("Connecting to: '" + process.env.KV_REST_API_URL + "'");
-
-const redis = new Redis({
+console.log("Setting up db settings bassed on vars in process.env");
+let redisOptions = {
     url: process.env.KV_REST_API_URL,
     token: process.env.KV_REST_API_TOKEN
-});
+};
+
+console.log("Connecting to: '" + redisOptions.url + "'");
+
+const redis = new Redis(redisOptions);
 
 await recreateLeagueData("amazing_race:35:", amazingRace35Data)
 await recreateLeagueData("amazing_race:36:", amazingRace36Data)


### PR DESCRIPTION
### Summary/Acceptance Criteria
This PR achieves the goal stated in #150 to
> Should have a way to target prod or non-prod
This commit adds two targets `seed:dev` & `seed:prod` so that one can seed the non-prod and prod dbs

### Screenshots
N/A

## Confirm
- [x] This PR has unit tests scenarios. (we aren't adding unit tests for this yet)
- [x] This PR is correctly linked to the relevant issue or milestone.
- [x] This PR has been locally QA'd. (this was run and tested  such that both dbs have now been seeded)

/assign me