### PR TITLE
Corrected show name in footer

### DIFF
--- a/app/[showStatus]/[showNameAndSeason]/contestants/page.tsx
+++ b/app/[showStatus]/[showNameAndSeason]/contestants/page.tsx
@@ -47,8 +47,9 @@ export default async function Contestants({ params }: {
     const showAndSeasonArr = showNameAndSeason.split('-');
     const showSeason = showAndSeasonArr.at(-1);
     showAndSeasonArr.pop();
-    const showName = showAndSeasonArr.map((word) => word.charAt(0).toUpperCase() + word.slice(1)).join('');
-    const fileName = `${showName}_${showSeason}`;
+    const showName = showAndSeasonArr.map((word) => word.charAt(0).toUpperCase() + word.slice(1));
+    const friendlyShowName = showName.join(' ');
+    const fileName = `${showName.join('')}_${showSeason}`;
     // "Dynamically" (still static site generated) retrieving modules
     const { WIKI_API_URL, WIKI_PAGE_URL, CAST_PHRASE, COMPETING_ENTITY_NAME } = await require(`../../../leagueConfiguration/${fileName}.js`);
 
@@ -79,7 +80,7 @@ export default async function Contestants({ params }: {
             <br/>
             <div>
                 <p>
-              Data provided by <a className="standard-link" href={WIKI_PAGE_URL} >Wikipedia</a> for this season of Big Brother
+                    Data provided by <a className="standard-link" href={WIKI_PAGE_URL} >Wikipedia</a> for this season of {friendlyShowName}
                 </p>
             </div>
         </div>

--- a/app/[showStatus]/[showNameAndSeason]/contestants/page.tsx
+++ b/app/[showStatus]/[showNameAndSeason]/contestants/page.tsx
@@ -47,9 +47,10 @@ export default async function Contestants({ params }: {
     const showAndSeasonArr = showNameAndSeason.split('-');
     const showSeason = showAndSeasonArr.at(-1);
     showAndSeasonArr.pop();
-    const showName = showAndSeasonArr.map((word) => word.charAt(0).toUpperCase() + word.slice(1));
-    const friendlyShowName = showName.join(' ');
-    const fileName = `${showName.join('')}_${showSeason}`;
+    const showNameArr = showAndSeasonArr.map((word) => word.charAt(0).toUpperCase() + word.slice(1));
+    const showName = showNameArr.join('');
+    const friendlyShowName = showNameArr.join(' ');
+    const fileName = `${showName}_${showSeason}`;
     // "Dynamically" (still static site generated) retrieving modules
     const { WIKI_API_URL, WIKI_PAGE_URL, CAST_PHRASE, COMPETING_ENTITY_NAME } = await require(`../../../leagueConfiguration/${fileName}.js`);
 


### PR DESCRIPTION
### Summary/Acceptance Criteria
Fixes the footer on the Contestants template to display show name instead of always showing "Big Brother"

### Screenshots
<img width="494" alt="image" src="https://github.com/user-attachments/assets/16f54020-b4d2-41c6-b700-8f5024e50e13" />

## Confirm
- [x] This PR has unit tests scenarios.
- [x] This PR is correctly linked to the relevant issue or milestone. (This is a bug fix, so no milestone)
- [x] This PR has been locally QA'd.

/assign me