### PR TITLE
Feature/refactor filename string manip

### DIFF
--- a/app/[showStatus]/[showNameAndSeason]/contestants/page.tsx
+++ b/app/[showStatus]/[showNameAndSeason]/contestants/page.tsx
@@ -1,4 +1,4 @@
-import {transformFilenameToSesonNameRepo } from "../../../utils/leagueUtils"
+import { transformFilenameToSesonNameRepo } from "../../../utils/leagueUtils"
 import { getCompetingEntityList, getTeamList, ITeam } from "../../../utils/wikiQuery";
 import { getWikipediaContestantData } from "../../../utils/wikiFetch";
 

--- a/app/[showStatus]/[showNameAndSeason]/contestants/page.tsx
+++ b/app/[showStatus]/[showNameAndSeason]/contestants/page.tsx
@@ -1,3 +1,4 @@
+import {transformFilenameToSesonNameRepo } from "../../../utils/leagueUtils"
 import { getCompetingEntityList, getTeamList, ITeam } from "../../../utils/wikiQuery";
 import { getWikipediaContestantData } from "../../../utils/wikiFetch";
 
@@ -23,10 +24,7 @@ export function generateStaticParams() {
       // Needed status for url
       const { LEAGUE_STATUS } = require(`../../../leagueConfiguration/${file}`);
       // Parses filename and converts it to url format
-      const showAndSeason = file.split('_');
-      const showNameFormatted = showAndSeason[0].split(/(?<![A-Z])(?=[A-Z])/).join('-').toLowerCase();
-      const showSeason = showAndSeason[1].replace('.js', '');
-      const showNameAndSeason = `${showNameFormatted}-${showSeason}`;
+      const { urlSlug: showNameAndSeason } = transformFilenameToSesonNameRepo(file)
       // Exporting properties as params
       const showPropertiesObj = {
         showNameAndSeason,

--- a/app/[showStatus]/[showNameAndSeason]/contestants/page.tsx
+++ b/app/[showStatus]/[showNameAndSeason]/contestants/page.tsx
@@ -1,4 +1,4 @@
-import { transformFilenameToSesonNameRepo } from "../../../utils/leagueUtils"
+import { transformFilenameToSeasonNameRepo } from "../../../utils/leagueUtils"
 import { getCompetingEntityList, getTeamList, ITeam } from "../../../utils/wikiQuery";
 import { getWikipediaContestantData } from "../../../utils/wikiFetch";
 
@@ -24,7 +24,7 @@ export function generateStaticParams() {
       // Needed status for url
       const { LEAGUE_STATUS } = require(`../../../leagueConfiguration/${file}`);
       // Parses filename and converts it to url format
-      const { urlSlug: showNameAndSeason } = transformFilenameToSesonNameRepo(file)
+      const { urlSlug: showNameAndSeason } = transformFilenameToSeasonNameRepo(file)
       // Exporting properties as params
       const showPropertiesObj = {
         showNameAndSeason,

--- a/app/[showStatus]/[showNameAndSeason]/league-standing/page.tsx
+++ b/app/[showStatus]/[showNameAndSeason]/league-standing/page.tsx
@@ -1,4 +1,4 @@
-import { transformFilenameToSesonNameRepo } from "../../../utils/leagueUtils"
+import { transformFilenameToSeasonNameRepo } from "../../../utils/leagueUtils"
 import { getWikipediaContestantDataFetcher } from "@/app/utils/wikiFetch";
 import LeagueStandingTable from "../../../components/leagueStandingTable/leagueStandingTable";
 import { getTeamList, getCompetingEntityList } from "@/app/utils/wikiQuery";
@@ -26,7 +26,7 @@ export function generateStaticParams() {
       // Needed status for url
       const { LEAGUE_STATUS } = require(`../../../leagueConfiguration/${file}`);
       // Parses filename and converts it to url format
-      const { urlSlug: showNameAndSeason } = transformFilenameToSesonNameRepo(file)
+      const { urlSlug: showNameAndSeason } = transformFilenameToSeasonNameRepo(file)
       // Exporting properties as params
       const showPropertiesObj = {
         showNameAndSeason,

--- a/app/[showStatus]/[showNameAndSeason]/league-standing/page.tsx
+++ b/app/[showStatus]/[showNameAndSeason]/league-standing/page.tsx
@@ -1,3 +1,4 @@
+import { transformFilenameToSesonNameRepo } from "../../../utils/leagueUtils"
 import { getWikipediaContestantDataFetcher } from "@/app/utils/wikiFetch";
 import LeagueStandingTable from "../../../components/leagueStandingTable/leagueStandingTable";
 import { getTeamList, getCompetingEntityList } from "@/app/utils/wikiQuery";
@@ -25,10 +26,7 @@ export function generateStaticParams() {
       // Needed status for url
       const { LEAGUE_STATUS } = require(`../../../leagueConfiguration/${file}`);
       // Parses filename and converts it to url format
-      const showAndSeason = file.split('_');
-      const showNameFormatted = showAndSeason[0].split(/(?<![A-Z])(?=[A-Z])/).join('-').toLowerCase();
-      const showSeason = showAndSeason[1].replace('.js', '');
-      const showNameAndSeason = `${showNameFormatted}-${showSeason}`;
+      const { urlSlug: showNameAndSeason } = transformFilenameToSesonNameRepo(file)
       // Exporting properties as params
       const showPropertiesObj = {
         showNameAndSeason,

--- a/app/[showStatus]/[showNameAndSeason]/scoring/page.tsx
+++ b/app/[showStatus]/[showNameAndSeason]/scoring/page.tsx
@@ -1,4 +1,4 @@
-import { transformFilenameToSesonNameRepo } from "../../../utils/leagueUtils"
+import { transformFilenameToSeasonNameRepo } from "../../../utils/leagueUtils"
 import ContestantSelector from '../../../components/contestantSelector'
 import { getCompetingEntityList } from "../../../utils/wikiQuery"
 import { getWikipediaContestantDataFetcher } from '../../../utils/wikiFetch'
@@ -28,7 +28,7 @@ export function generateStaticParams() {
       // Needed status for url
       const { LEAGUE_STATUS } = require(`../../../leagueConfiguration/${file}`);
       // Parses filename and converts it to url format
-      const { urlSlug: showNameAndSeason } = transformFilenameToSesonNameRepo(file)
+      const { urlSlug: showNameAndSeason } = transformFilenameToSeasonNameRepo(file)
       // Exporting properties as params
       const showPropertiesObj = {
         showNameAndSeason,

--- a/app/[showStatus]/[showNameAndSeason]/scoring/page.tsx
+++ b/app/[showStatus]/[showNameAndSeason]/scoring/page.tsx
@@ -1,4 +1,4 @@
-import {transformFilenameToSesonNameRepo } from "../../../utils/leagueUtils"
+import { transformFilenameToSesonNameRepo } from "../../../utils/leagueUtils"
 import ContestantSelector from '../../../components/contestantSelector'
 import { getCompetingEntityList } from "../../../utils/wikiQuery"
 import { getWikipediaContestantDataFetcher } from '../../../utils/wikiFetch'

--- a/app/[showStatus]/[showNameAndSeason]/scoring/page.tsx
+++ b/app/[showStatus]/[showNameAndSeason]/scoring/page.tsx
@@ -1,3 +1,4 @@
+import {transformFilenameToSesonNameRepo } from "../../../utils/leagueUtils"
 import ContestantSelector from '../../../components/contestantSelector'
 import { getCompetingEntityList } from "../../../utils/wikiQuery"
 import { getWikipediaContestantDataFetcher } from '../../../utils/wikiFetch'
@@ -27,10 +28,7 @@ export function generateStaticParams() {
       // Needed status for url
       const { LEAGUE_STATUS } = require(`../../../leagueConfiguration/${file}`);
       // Parses filename and converts it to url format
-      const showAndSeason = file.split('_');
-      const showNameFormatted = showAndSeason[0].split(/(?<![A-Z])(?=[A-Z])/).join('-').toLowerCase();
-      const showSeason = showAndSeason[1].replace('.js', '');
-      const showNameAndSeason = `${showNameFormatted}-${showSeason}`;
+      const { urlSlug: showNameAndSeason } = transformFilenameToSesonNameRepo(file)
       // Exporting properties as params
       const showPropertiesObj = {
         showNameAndSeason,

--- a/app/utils/leagueUtils.tsx
+++ b/app/utils/leagueUtils.tsx
@@ -10,7 +10,7 @@ export function transformFilenameToSeasonNameRepo(fileName: string): SeasonNameR
     const showNameFormatted = showNameArray.join('-').toLowerCase();
     const showSeason = showAndSeason[1].replace('.js', '');
     const showNameAndSeason = `${showNameFormatted}-${showSeason}`;
-    let friendlyName = `${showNameArray.join(' ')} ${showSeason}`;
+    const friendlyName = `${showNameArray.join(' ')} ${showSeason}`;
 
     return { urlSlug: showNameAndSeason, friendlyName: friendlyName }
 }

--- a/app/utils/leagueUtils.tsx
+++ b/app/utils/leagueUtils.tsx
@@ -1,0 +1,17 @@
+
+export interface SeasonNameRepo {
+    urlSlug: string
+    friendlyName: string
+}
+
+export function transformFilenameToSesonNameRepo(fileName: string): SeasonNameRepo {
+    const showAndSeason = fileName.split('_');
+    const showNameArray = showAndSeason[0].split(/(?<![A-Z])(?=[A-Z])/);
+    const showNameFormatted = showNameArray.join('-').toLowerCase();
+    const showSeason = showAndSeason[1].replace('.js', '');
+    const showNameAndSeason = `${showNameFormatted}-${showSeason}`;
+    let friendlyName = `${showNameArray.join(' ')} ${showSeason}`;
+
+    return { urlSlug: showNameAndSeason, friendlyName: friendlyName }
+}
+

--- a/app/utils/leagueUtils.tsx
+++ b/app/utils/leagueUtils.tsx
@@ -4,7 +4,7 @@ export interface SeasonNameRepo {
     friendlyName: string
 }
 
-export function transformFilenameToSesonNameRepo(fileName: string): SeasonNameRepo {
+export function transformFilenameToSeasonNameRepo(fileName: string): SeasonNameRepo {
     const showAndSeason = fileName.split('_');
     const showNameArray = showAndSeason[0].split(/(?<![A-Z])(?=[A-Z])/);
     const showNameFormatted = showNameArray.join('-').toLowerCase();

--- a/app/utils/pages.tsx
+++ b/app/utils/pages.tsx
@@ -56,8 +56,8 @@ export function getPages(): ILeagueLink[] {
     return paths;
 }
 
-function transformFilenameToSesonNameRepo(file: string) {
-    const showAndSeason = file.split('_');
+function transformFilenameToSesonNameRepo(fileName: string) {
+    const showAndSeason = fileName.split('_');
     const showNameArray = showAndSeason[0].split(/(?<![A-Z])(?=[A-Z])/);
     const showNameFormatted = showNameArray.join('-').toLowerCase();
     const showSeason = showAndSeason[1].replace('.js', '');

--- a/app/utils/pages.tsx
+++ b/app/utils/pages.tsx
@@ -1,3 +1,5 @@
+import {transformFilenameToSesonNameRepo } from "./leagueUtils"
+
 interface ILeagueLink {
     name: string
     subpages: IPage[]
@@ -54,21 +56,5 @@ export function getPages(): ILeagueLink[] {
     });
     const paths:Array<ILeagueLink> = activeLeaguePaths.concat(archiveLeaguePaths);
     return paths;
-}
-
-interface SeasonNameRepo {
-    urlSlug: string
-    friendlyName: string
-}
-
-function transformFilenameToSesonNameRepo(fileName: string): SeasonNameRepo {
-    const showAndSeason = fileName.split('_');
-    const showNameArray = showAndSeason[0].split(/(?<![A-Z])(?=[A-Z])/);
-    const showNameFormatted = showNameArray.join('-').toLowerCase();
-    const showSeason = showAndSeason[1].replace('.js', '');
-    const showNameAndSeason = `${showNameFormatted}-${showSeason}`;
-    let friendlyName = `${showNameArray.join(' ')} ${showSeason}`;
-
-    return { urlSlug: showNameAndSeason, friendlyName: friendlyName }
 }
 

--- a/app/utils/pages.tsx
+++ b/app/utils/pages.tsx
@@ -21,7 +21,7 @@ export function getPages(): ILeagueLink[] {
         // Needed status for url
         const { LEAGUE_STATUS } = require(`../leagueConfiguration/${file}`);
         // Parses filename and converts it to url format
-        const pageStrings = get(file);
+        const pageStrings = transformFilenameToSesonNameRepo(file);
         const subpages:Array<IPage> = [];
         subpages.push({
             name: "Contestants",
@@ -56,7 +56,7 @@ export function getPages(): ILeagueLink[] {
     return paths;
 }
 
-function get(file: string) {
+function transformFilenameToSesonNameRepo(file: string) {
     const showAndSeason = file.split('_');
     const showNameArray = showAndSeason[0].split(/(?<![A-Z])(?=[A-Z])/);
     const showNameFormatted = showNameArray.join('-').toLowerCase();

--- a/app/utils/pages.tsx
+++ b/app/utils/pages.tsx
@@ -29,7 +29,7 @@ export function getPages(): ILeagueLink[] {
             name: "Contestants",
             path: `/${LEAGUE_STATUS}/${pageStrings.urlSlug}/contestants`
         });
-        if(fs.existsSync(path.join(process.cwd(), 'app', 'leagueData', file))){
+        if(fs.existsSync(path.join(process.cwd(), "app", "leagueData", file))){
             const scoringSubpage = {
                 name: "Scoring",
                 path: `/${LEAGUE_STATUS}/${pageStrings.urlSlug}/scoring`
@@ -40,7 +40,7 @@ export function getPages(): ILeagueLink[] {
             }
             subpages.push(scoringSubpage, leagueStandingSubpage);
         }
-        if(LEAGUE_STATUS === 'active'){
+        if(LEAGUE_STATUS === "active"){
             pageStrings.friendlyName = `Current (${pageStrings.friendlyName})`
         }
         //   Path object created

--- a/app/utils/pages.tsx
+++ b/app/utils/pages.tsx
@@ -1,4 +1,4 @@
-import { transformFilenameToSesonNameRepo } from "./leagueUtils"
+import { transformFilenameToSeasonNameRepo } from "./leagueUtils"
 
 interface ILeagueLink {
     name: string
@@ -23,7 +23,7 @@ export function getPages(): ILeagueLink[] {
         // Needed status for url
         const { LEAGUE_STATUS } = require(`../leagueConfiguration/${file}`);
         // Parses filename and converts it to url format
-        const pageStrings = transformFilenameToSesonNameRepo(file);
+        const pageStrings = transformFilenameToSeasonNameRepo(file);
         const subpages:Array<IPage> = [];
         subpages.push({
             name: "Contestants",

--- a/app/utils/pages.tsx
+++ b/app/utils/pages.tsx
@@ -56,7 +56,12 @@ export function getPages(): ILeagueLink[] {
     return paths;
 }
 
-function transformFilenameToSesonNameRepo(fileName: string) {
+interface SeasonNameRepo {
+    urlSlug: string
+    friendlyName: string
+}
+
+function transformFilenameToSesonNameRepo(fileName: string): SeasonNameRepo {
     const showAndSeason = fileName.split('_');
     const showNameArray = showAndSeason[0].split(/(?<![A-Z])(?=[A-Z])/);
     const showNameFormatted = showNameArray.join('-').toLowerCase();

--- a/app/utils/pages.tsx
+++ b/app/utils/pages.tsx
@@ -21,34 +21,29 @@ export function getPages(): ILeagueLink[] {
         // Needed status for url
         const { LEAGUE_STATUS } = require(`../leagueConfiguration/${file}`);
         // Parses filename and converts it to url format
-        const showAndSeason = file.split("_");
-        const showNameArray = showAndSeason[0].split(/(?<![A-Z])(?=[A-Z])/);
-        const showNameFormatted = showNameArray.join("-").toLowerCase();
-        const showSeason = showAndSeason[1].replace(".js", "");
-        const showNameAndSeason = `${showNameFormatted}-${showSeason}`;
-        let friendlyName = `${showNameArray.join(" ")} ${showSeason}`;
+        const pageStrings = get(file);
         const subpages:Array<IPage> = [];
         subpages.push({
             name: "Contestants",
-            path: `/${LEAGUE_STATUS}/${showNameAndSeason}/contestants`
+            path: `/${LEAGUE_STATUS}/${pageStrings.urlSlug}/contestants`
         });
-        if(fs.existsSync(path.join(process.cwd(), "app", "leagueData", file))){
+        if(fs.existsSync(path.join(process.cwd(), 'app', 'leagueData', file))){
             const scoringSubpage = {
                 name: "Scoring",
-                path: `/${LEAGUE_STATUS}/${showNameAndSeason}/scoring`
+                path: `/${LEAGUE_STATUS}/${pageStrings.urlSlug}/scoring`
             }
             const leagueStandingSubpage = {
                 name: "League Standing",
-                path: `/${LEAGUE_STATUS}/${showNameAndSeason}/league-standing`
+                path: `/${LEAGUE_STATUS}/${pageStrings.urlSlug}/league-standing`
             }
             subpages.push(scoringSubpage, leagueStandingSubpage);
         }
-        if(LEAGUE_STATUS === "active"){
-            friendlyName = `Current (${friendlyName})`
+        if(LEAGUE_STATUS === 'active'){
+            pageStrings.friendlyName = `Current (${pageStrings.friendlyName})`
         }
         //   Path object created
         const pathObj = {
-            name: friendlyName,
+            name: pageStrings.friendlyName,
             subpages: subpages
         }
         if(LEAGUE_STATUS === "active"){
@@ -60,3 +55,15 @@ export function getPages(): ILeagueLink[] {
     const paths:Array<ILeagueLink> = activeLeaguePaths.concat(archiveLeaguePaths);
     return paths;
 }
+
+function get(file: string) {
+    const showAndSeason = file.split('_');
+    const showNameArray = showAndSeason[0].split(/(?<![A-Z])(?=[A-Z])/);
+    const showNameFormatted = showNameArray.join('-').toLowerCase();
+    const showSeason = showAndSeason[1].replace('.js', '');
+    const showNameAndSeason = `${showNameFormatted}-${showSeason}`;
+    let friendlyName = `${showNameArray.join(' ')} ${showSeason}`;
+
+    return { urlSlug: showNameAndSeason, friendlyName: friendlyName }
+}
+

--- a/app/utils/pages.tsx
+++ b/app/utils/pages.tsx
@@ -1,4 +1,4 @@
-import {transformFilenameToSesonNameRepo } from "./leagueUtils"
+import { transformFilenameToSesonNameRepo } from "./leagueUtils"
 
 interface ILeagueLink {
     name: string


### PR DESCRIPTION
### Summary/Acceptance Criteria
This is just a small refactor that makes it so that the funky fileName string manipulation we have been using to come up with both a urlSlug and also a Friendly name to display to users is now in a centuralizable place where we can reuse that logic and eventually replace it when we instead need to get those things based off of something from the DB.

### Screenshots
N/A this is visually the same the change is all a behind the scenes refactor.

## Confirm
- [ ] This PR has unit tests scenarios. (Unclear if this needs tests 🤔, we agreed that they are not needed for this)
- [x] This PR is correctly linked to the relevant issue or milestone. (not really sure where this goes 🤔)
- [x] This PR has been locally QA'd. (This does work 😁)

/assign me