### PR TITLE
194 update league standing page to read from db

### DIFF
--- a/app/[showStatus]/[showNameAndSeason]/league-standing/page.tsx
+++ b/app/[showStatus]/[showNameAndSeason]/league-standing/page.tsx
@@ -50,7 +50,6 @@ export default async function LeagueStanding({ params }: {
     const showName = showAndSeasonArr.map((word) => word.charAt(0).toUpperCase() + word.slice(1)).join('');
     const fileName = `${showName}_${showSeason}`;
     // "Dynamically" (still static site generated) retrieving modules
-    const { CONTESTANT_LEAGUE_DATA } = await require(`../../../leagueData/${fileName}.js`);
     const { WIKI_API_URL, CAST_PHRASE, CONTESTANT_LEAGUE_DATA_KEY_PREFIX } = await require(`../../../leagueConfiguration/${fileName}.js`);
     const dataFetcher = getWikipediaContestantDataFetcher(WIKI_API_URL, CAST_PHRASE);
     const contestantRoundData = await getContestantData(CONTESTANT_LEAGUE_DATA_KEY_PREFIX);

--- a/app/[showStatus]/[showNameAndSeason]/league-standing/page.tsx
+++ b/app/[showStatus]/[showNameAndSeason]/league-standing/page.tsx
@@ -3,6 +3,7 @@ import { getWikipediaContestantDataFetcher } from "@/app/dataSources/wikiFetch"
 import LeagueStandingTable from "../../../components/leagueStandingTable/leagueStandingTable";
 import { getTeamList, getCompetingEntityList } from "@/app/utils/wikiQuery";
 import { generateContestantRoundScores } from "@/app/generators/contestantRoundScoreGenerator";
+import { getContestantData } from "@/app/dataSources/dbFetch"
 
 // This forces Next to only generate routes that exist in generateStaticParams, otherwise return a 404
 export const dynamicParams = false
@@ -52,6 +53,7 @@ export default async function LeagueStanding({ params }: {
     const { CONTESTANT_LEAGUE_DATA } = await require(`../../../leagueData/${fileName}.js`);
     const { WIKI_API_URL, CAST_PHRASE, CONTESTANT_LEAGUE_DATA_KEY_PREFIX } = await require(`../../../leagueConfiguration/${fileName}.js`);
     const dataFetcher = getWikipediaContestantDataFetcher(WIKI_API_URL, CAST_PHRASE);
+    const contestantRoundData = await getContestantData(CONTESTANT_LEAGUE_DATA_KEY_PREFIX);
 
     const getEntityFn = showName.match('AmazingRace') ? getTeamList : getCompetingEntityList;
     

--- a/app/[showStatus]/[showNameAndSeason]/league-standing/page.tsx
+++ b/app/[showStatus]/[showNameAndSeason]/league-standing/page.tsx
@@ -50,7 +50,7 @@ export default async function LeagueStanding({ params }: {
     const fileName = `${showName}_${showSeason}`;
     // "Dynamically" (still static site generated) retrieving modules
     const { CONTESTANT_LEAGUE_DATA } = await require(`../../../leagueData/${fileName}.js`);
-    const { WIKI_API_URL, CAST_PHRASE } = await require(`../../../leagueConfiguration/${fileName}.js`);
+    const { WIKI_API_URL, CAST_PHRASE, CONTESTANT_LEAGUE_DATA_KEY_PREFIX } = await require(`../../../leagueConfiguration/${fileName}.js`);
     const dataFetcher = getWikipediaContestantDataFetcher(WIKI_API_URL, CAST_PHRASE);
 
     const getEntityFn = showName.match('AmazingRace') ? getTeamList : getCompetingEntityList;

--- a/app/[showStatus]/[showNameAndSeason]/league-standing/page.tsx
+++ b/app/[showStatus]/[showNameAndSeason]/league-standing/page.tsx
@@ -57,7 +57,7 @@ export default async function LeagueStanding({ params }: {
 
     const getEntityFn = showName.match('AmazingRace') ? getTeamList : getCompetingEntityList;
     
-    const contestantsScores = await generateContestantRoundScores(dataFetcher, getEntityFn, CONTESTANT_LEAGUE_DATA);
+    const contestantsScores = await generateContestantRoundScores(dataFetcher, getEntityFn, contestantRoundData);
     return (
         <div>
             <h1 className="text-3xl text-center">League Standing</h1>

--- a/app/[showStatus]/[showNameAndSeason]/scoring/page.tsx
+++ b/app/[showStatus]/[showNameAndSeason]/scoring/page.tsx
@@ -3,7 +3,7 @@ import ContestantSelector from '../../../components/contestantSelector'
 import { getCompetingEntityList } from "../../../utils/wikiQuery"
 import { getWikipediaContestantDataFetcher } from '../../../dataSources/wikiFetch'
 import generateListOfContestantRoundLists from '../../../generators/contestantRoundListGenerator'
-import { Redis } from "@upstash/redis"
+import { getContestantData } from "@/app/dataSources/dbFetch"
 
 // This forces Next to only generate routes that exist in generateStaticParams, otherwise return a 404
 export const dynamicParams = false
@@ -38,28 +38,6 @@ export function generateStaticParams() {
       shows.push(showPropertiesObj);
     });
     return shows;
-}
-
-async function getContestantData(keyPrefix: string): Promise<any[]> {
-
-    if (keyPrefix === undefined) {
-        throw new Error(`Unable to getContestantData. Provided param 'keySpace' is undefined but must have a value"`);
-    }
-
-    const redis = new Redis({
-        url: process.env.KV_REST_API_URL,
-        token: process.env.KV_REST_API_TOKEN
-    })
-
-    const userCursor = await redis.scan("0", {match: keyPrefix})
-    const userLeagueKeys = userCursor[1] // get's the list of keys in the cursor
-    const userList = []
-    for (let i = 0; i < userLeagueKeys.length; i++) {
-        const userData = await redis.json.get(userLeagueKeys[i])
-        userList.push(userData)
-    }
-
-    return userList
 }
 
 export default async function Scoring({ params }: {

--- a/app/dataSources/dbFetch.tsx
+++ b/app/dataSources/dbFetch.tsx
@@ -12,14 +12,12 @@ export async function getContestantData(keyPrefix: string): Promise<any[]> {
     })
 
     const userCursor = await redis.scan("0", {match: keyPrefix})
-    console.log(userCursor)
     const userLeagueKeys = userCursor[1] // get's the list of keys in the cursor
     const userList = []
     for (let i = 0; i < userLeagueKeys.length; i++) {
         const userData = await redis.json.get(userLeagueKeys[i])
         userList.push(userData)
     }
-    console.log(userList)
 
     return userList
 }

--- a/app/dataSources/dbFetch.tsx
+++ b/app/dataSources/dbFetch.tsx
@@ -1,0 +1,25 @@
+import { Redis } from "@upstash/redis"
+
+export async function getContestantData(keyPrefix: string): Promise<any[]> {
+
+    if (keyPrefix === undefined) {
+        throw new Error(`Unable to getContestantData. Provided param 'keySpace' is undefined but must have a value"`);
+    }
+
+    const redis = new Redis({
+        url: process.env.KV_REST_API_URL,
+        token: process.env.KV_REST_API_TOKEN
+    })
+
+    const userCursor = await redis.scan("0", {match: keyPrefix})
+    console.log(userCursor)
+    const userLeagueKeys = userCursor[1] // get's the list of keys in the cursor
+    const userList = []
+    for (let i = 0; i < userLeagueKeys.length; i++) {
+        const userData = await redis.json.get(userLeagueKeys[i])
+        userList.push(userData)
+    }
+    console.log(userList)
+
+    return userList
+}


### PR DESCRIPTION
_WIP: depends on #200 so will be left in draft until then_

### Summary/Acceptance Criteria
Just as the name implies this change will update all the league-standing pages (by way of templating) to read leagueContestant data from the db. This effectively makes the whole site dependant on the leagueContestant data from the DB.

### Screenshots
N/A purely a backend change.

## Confirm
- [x] This PR has unit tests scenarios. (No new behavior to test)
- [ ] This PR is correctly linked to the relevant issue or milestone.
- [x] This PR has been locally QA'd. (YUP 😁)

/assign me