### PR TITLE
155 update build process to run db seed target

### DIFF
--- a/.github/workflows/seedProd.yml
+++ b/.github/workflows/seedProd.yml
@@ -1,0 +1,27 @@
+# This workflow will do a clean installation of node dependencies, cache/restore them, build the source code and run tests across different versions of node
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs
+
+name: Node.js CI
+
+on:
+  push:
+    branches: [ "main" ]
+
+jobs:
+  seed:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [20.x]
+        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v3
+      with:
+        node-version: ${{ matrix.node-version }}
+        cache: 'npm'
+    - run: npm seed:prod

--- a/.github/workflows/seedProd.yml
+++ b/.github/workflows/seedProd.yml
@@ -1,7 +1,7 @@
 # This workflow will do a clean installation of node dependencies, cache/restore them, build the source code and run tests across different versions of node
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs
 
-name: Node.js CI
+name: Seed Production DB
 
 on:
   push:

--- a/.github/workflows/seedProd.yml
+++ b/.github/workflows/seedProd.yml
@@ -4,8 +4,10 @@
 name: Seed Production DB
 
 on:
-  push:
-    branches: [ "main" ]
+  workflow_run:
+    workflows: [Node.js CI]
+    types: [completed]
+    branches: [main]
 
 jobs:
   seed:

--- a/.github/workflows/seedProd.yml
+++ b/.github/workflows/seedProd.yml
@@ -12,6 +12,8 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    environment: production
+
     strategy:
       matrix:
         node-version: [20.x]

--- a/.github/workflows/seedProd.yml
+++ b/.github/workflows/seedProd.yml
@@ -29,3 +29,7 @@ jobs:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
     - run: npm seed:prod
+      env:
+        KV_REST_API_URL: ${{ secrets.KV_REST_API_URL }}
+        KV_REST_API_TOKEN: ${{ secrets.KV_REST_API_TOKEN }}
+


### PR DESCRIPTION
### Summary/Acceptance Criteria
This PR is adding a github action to run whenever a merge to `main` happens. It will run the `seed:prod` stage updating the production DB

_Note: there could be a race condition between this running and the prod deployment which is also triggered by the merge_
- I think what we have learned is we aren't much concerned with this potential race condition here because [ISR](https://nextjs.org/docs/pages/building-your-application/data-fetching/incremental-static-regeneration) takes care of us here!

### Screenshots
N/A just setting up a new workflow

## Confirm
- [ ] This PR has unit tests scenarios. (N/A not chaning functionality no way of adding a unit test for it)
- [x] This PR is correctly linked to the relevant issue or milestone.
- [ ] This PR has been locally QA'd. (N/A can only really test this when running in github)

/assign me