### PR TITLE
Add react version to eslint

### DIFF
--- a/app/[showStatus]/[showNameAndSeason]/contestants/page.tsx
+++ b/app/[showStatus]/[showNameAndSeason]/contestants/page.tsx
@@ -47,8 +47,9 @@ export default async function Contestants({ params }: {
     const showAndSeasonArr = showNameAndSeason.split('-');
     const showSeason = showAndSeasonArr.at(-1);
     showAndSeasonArr.pop();
-    const showName = showAndSeasonArr.map((word) => word.charAt(0).toUpperCase() + word.slice(1)).join('');
-    const fileName = `${showName}_${showSeason}`;
+    const showName = showAndSeasonArr.map((word) => word.charAt(0).toUpperCase() + word.slice(1));
+    const friendlyShowName = showName.join(' ');
+    const fileName = `${showName.join('')}_${showSeason}`;
     // "Dynamically" (still static site generated) retrieving modules
     const { WIKI_API_URL, WIKI_PAGE_URL, CAST_PHRASE, COMPETING_ENTITY_NAME } = await require(`../../../leagueConfiguration/${fileName}.js`);
 
@@ -79,7 +80,7 @@ export default async function Contestants({ params }: {
             <br/>
             <div>
                 <p>
-              Data provided by <a className="standard-link" href={WIKI_PAGE_URL} >Wikipedia</a> for this season of Big Brother
+                    Data provided by <a className="standard-link" href={WIKI_PAGE_URL} >Wikipedia</a> for this season of {friendlyShowName}
                 </p>
             </div>
         </div>

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -5,7 +5,12 @@ import pluginReactConfig from "eslint-plugin-react/configs/recommended.js";
 
 export default [
     {
-        ignores: [".next", "node_modules"]
+        ignores: [".next", "node_modules"],
+        settings: {
+            react: {
+                version: "detect"
+            }
+        }
     },
     pluginJs.configs.recommended,
     ...tseslint.configs.recommended,


### PR DESCRIPTION
### Summary/Acceptance Criteria
Added missing eslint config value

This fixes the following error in the console: 

Warning: React version not specified in eslint-plugin-react settings. See https://github.com/jsx-eslint/eslint-plugin-react#configuration .
<img width="1171" alt="image" src="https://github.com/user-attachments/assets/2512263c-550a-4d6c-9426-3364119c81b0" />


## Confirm
- [x] This PR has unit tests scenarios. (ESLint doesn't error)
- [x] This PR is correctly linked to the relevant issue or milestone.
- [x] This PR has been locally QA'd.

/assign me