### PR TITLE
Feature/fix fork elim bug

### DIFF
--- a/__tests__/utils/wikiQuery.js
+++ b/__tests__/utils/wikiQuery.js
@@ -23,26 +23,6 @@ describe("getTeamList", () => {
         expect(result).not.toBeNull();
     });
 
-    it("should throw an error for a contestantData w/ a missing status for second on a team", () => {
-        // Arrange
-        const firstContestantsFirstName = "Some";
-        const secondContestantsFirstName = "SomeGuys";
-
-        const listOfContestants = [
-            {
-                name: firstContestantsFirstName + " Guy",
-                col4: "Participating"
-            },
-            {name: secondContestantsFirstName + " Brother"}
-        ];
-
-        // Act
-        var act = () => getTeamList(listOfContestants);
-
-        // Assert
-        expect(act).toThrow(new ReferenceError("Status is either null or undefined and it should not be"));
-    });
-
     it("Should parse out elimination order and populate it when the team is not participating", () => {
         const firstContestantsFirstName = "Some";
         const secondContestantsFirstName = "SomeGuys";

--- a/__tests__/utils/wikiQuery.js
+++ b/__tests__/utils/wikiQuery.js
@@ -23,27 +23,6 @@ describe("getTeamList", () => {
         expect(result).not.toBeNull();
     });
 
-    it("Should parse out elimination order and populate it when the team is not participating", () => {
-        const firstContestantsFirstName = "Some";
-        const secondContestantsFirstName = "SomeGuys";
-        const expectedEliminationOrder = 2;
-
-        const listOfContestants = [
-            {
-                name: firstContestantsFirstName + " Guy",
-                col4: "Eliminated " + expectedEliminationOrder + "nd"
-            },
-            {
-                name: secondContestantsFirstName + " Brother",
-                col4: "Eliminated " + expectedEliminationOrder + "nd"
-            }
-        ];
-
-        var result = getTeamList(listOfContestants);
-
-        expect(result[0].eliminationOrder).toEqual(2);
-    });
-
     it("should return two teams that have isParticipating false when only the first contestant/team has a status and the second team is not participating", () => {
         // Arrange
         const firstContestantsFirstName = "Some";
@@ -76,6 +55,27 @@ describe("getTeamList", () => {
         expect(result.length).toEqual(2);
         expect(result[0].isParticipating).toBeFalsy()
         expect(result[1].isParticipating).toBeFalsy()
+    });
+
+    it("Should parse out elimination order and populate it when the team is not participating", () => {
+        const firstContestantsFirstName = "Some";
+        const secondContestantsFirstName = "SomeGuys";
+        const expectedEliminationOrder = 2;
+
+        const listOfContestants = [
+            {
+                name: firstContestantsFirstName + " Guy",
+                col4: "Eliminated " + expectedEliminationOrder + "nd"
+            },
+            {
+                name: secondContestantsFirstName + " Brother",
+                col4: "Eliminated " + expectedEliminationOrder + "nd"
+            }
+        ];
+
+        var result = getTeamList(listOfContestants);
+
+        expect(result[0].eliminationOrder).toEqual(2);
     });
 
     it("Should parse out elimination order when a team is third", () => {

--- a/__tests__/utils/wikiQuery.js
+++ b/__tests__/utils/wikiQuery.js
@@ -44,6 +44,40 @@ describe("getTeamList", () => {
         expect(result[0].eliminationOrder).toEqual(2);
     });
 
+    it("should return two teams that have isParticipating false when only the first contestant/team has a status and the second team is not participating", () => {
+        // Arrange
+        const firstContestantsFirstName = "Some";
+        const secondContestantsFirstName = "SomeGuys";
+
+        const listOfContestants = [
+            {
+                name: firstContestantsFirstName + " Guy",
+                col4: "Eliminated 1st & 2nd"
+            },
+            {
+                name: secondContestantsFirstName + " Brother",
+                col4: ""
+            },
+            {
+                name: "3rdContestantSecondTeam" + " Guy",
+                col4: ""
+            },
+            {
+                name: "4thContestantSecondTeam" + " Brother",
+                col4: ""
+            }
+        ];
+
+        // Act
+        var result = getTeamList(listOfContestants);
+
+        // Assert
+        expect(result).not.toBeNull();
+        expect(result.length).toEqual(2);
+        expect(result[0].isParticipating).toBeFalsy()
+        expect(result[1].isParticipating).toBeFalsy()
+    });
+
     it("Should parse out elimination order when a team is third", () => {
         const firstContestantsFirstName = "Some";
         const secondContestantsFirstName = "SomeGuys";

--- a/app/utils/wikiQuery.tsx
+++ b/app/utils/wikiQuery.tsx
@@ -13,6 +13,9 @@ export function getTeamList(contestantData :ITableRowData[]): Team[] {
     contestantData.forEach((element) => {
 
         let status = element.col4;
+        if (status === null || status === undefined || status === "") {
+            status = previousStatus
+        }
 
         const teamName = element.name;
 

--- a/app/utils/wikiQuery.tsx
+++ b/app/utils/wikiQuery.tsx
@@ -8,6 +8,8 @@ export function getTeamList(contestantData :ITableRowData[]): Team[] {
     let firstContestantFound: boolean = false;
     let teamStarted: boolean = false;
 
+    let previousStatus = "";
+
     contestantData.forEach((element) => {
 
         const status = element.col4;

--- a/app/utils/wikiQuery.tsx
+++ b/app/utils/wikiQuery.tsx
@@ -12,13 +12,13 @@ export function getTeamList(contestantData :ITableRowData[]): Team[] {
 
     contestantData.forEach((element) => {
 
+        const teamName = element.name;
+
         let status = element.col4;
         if (status === null || status === undefined || status === "") {
             status = previousStatus
         }
         previousStatus = status;
-
-        const teamName = element.name;
 
         if (!firstContestantFound && isPartialContestantData(element)) {
             return;

--- a/app/utils/wikiQuery.tsx
+++ b/app/utils/wikiQuery.tsx
@@ -12,7 +12,8 @@ export function getTeamList(contestantData :ITableRowData[]): Team[] {
 
     contestantData.forEach((element) => {
 
-        const status = element.col4;
+        let status = element.col4;
+
         const teamName = element.name;
 
         if (status === null || status === undefined) {

--- a/app/utils/wikiQuery.tsx
+++ b/app/utils/wikiQuery.tsx
@@ -16,10 +16,9 @@ export function getTeamList(contestantData :ITableRowData[]): Team[] {
         if (status === null || status === undefined || status === "") {
             status = previousStatus
         }
+        previousStatus = status;
 
         const teamName = element.name;
-
-        previousStatus = status;
 
         if (!firstContestantFound && isPartialContestantData(element)) {
             return;

--- a/app/utils/wikiQuery.tsx
+++ b/app/utils/wikiQuery.tsx
@@ -19,6 +19,8 @@ export function getTeamList(contestantData :ITableRowData[]): Team[] {
             throw new ReferenceError("Status is either null or undefined and it should not be");
         }
 
+        previousStatus = status;
+
         if (!firstContestantFound && isPartialContestantData(element)) {
             return;
         }

--- a/app/utils/wikiQuery.tsx
+++ b/app/utils/wikiQuery.tsx
@@ -19,10 +19,6 @@ export function getTeamList(contestantData :ITableRowData[]): Team[] {
 
         const teamName = element.name;
 
-        if (status === null || status === undefined) {
-            throw new ReferenceError("Status is either null or undefined and it should not be");
-        }
-
         previousStatus = status;
 
         if (!firstContestantFound && isPartialContestantData(element)) {


### PR DESCRIPTION
~_WIP: depends on #218_~

### Summary/Acceptance Criteria
Since this season of amazing race has a "fork" in season one resulting in two teams being eliminated and the "second" team in the wiki list wasn't being crossed off as eliminated on the contestants page, this address that.

### Screenshots
Before: 
<img width="392" alt="image" src="https://github.com/user-attachments/assets/bc31ccca-520c-4ccd-a9b2-744ae6ca272e" />
After:
<img width="365" alt="image" src="https://github.com/user-attachments/assets/ab12fade-3195-45cd-b328-23148616ec19" />


## Confirm
- [x] This PR has unit tests scenarios. (I did remove one, but I added a new one to assert the new behavior)
- [x] This PR is correctly linked to the relevant issue or milestone.
- [x] This PR has been locally QA'd.

/assign me