### PR TITLE
Feature/fix rounds to be based on unique elim order

### DIFF
--- a/__tests__/utils/teamListUtils.js
+++ b/__tests__/utils/teamListUtils.js
@@ -65,7 +65,6 @@ describe("teamListUtils shouldBeScored", () => {
 
 describe("getNumberOfRounds", () => {
     it("should not ever return Number.MAX_VALUE", () => {
-
         //Arrange
         const teamList = [{eliminationOrder: 1}, {eliminationOrder:2}, {eliminationOrder: Number.MAX_VALUE}];
 

--- a/__tests__/utils/teamListUtils.js
+++ b/__tests__/utils/teamListUtils.js
@@ -90,4 +90,19 @@ describe("getNumberOfRounds", () => {
         // Assert
         expect(result).toBe(2);
     });
+
+    it("Should not countin Number.MAX_VALUE as a unique number", () => {
+        //Arrange
+        const teamList = [
+            {eliminationOrder: 1},
+            {eliminationOrder: 3},
+            {eliminationOrder: Number.MAX_VALUE}
+        ];
+
+        // Act
+        const result = getNumberOfRounds(teamList);
+
+        // Assert
+        expect(result).toBe(2);
+    });
 });

--- a/__tests__/utils/teamListUtils.js
+++ b/__tests__/utils/teamListUtils.js
@@ -75,4 +75,19 @@ describe("getNumberOfRounds", () => {
         // Assert
         expect(result).not.toBe(Number.MAX_VALUE);
     });
+
+    it("Should return the number of unique eliminationOrders", () => {
+        //Arrange
+        const teamList = [
+            {eliminationOrder: 1},
+            {eliminationOrder: 1},
+            {eliminationOrder: 3},
+        ];
+
+        // Act
+        const result = getNumberOfRounds(teamList);
+
+        // Assert
+        expect(result).toBe(2);
+    });
 });

--- a/__tests__/utils/teamListUtils.js
+++ b/__tests__/utils/teamListUtils.js
@@ -105,4 +105,19 @@ describe("getNumberOfRounds", () => {
         // Assert
         expect(result).toBe(2);
     });
+
+    it("Should not countin 0 as a unique number", () => {
+        //Arrange
+        const teamList = [
+            {eliminationOrder: 1},
+            {eliminationOrder: 3},
+            {eliminationOrder: 0}
+        ];
+
+        // Act
+        const result = getNumberOfRounds(teamList);
+
+        // Assert
+        expect(result).toBe(2);
+    });
 });

--- a/app/utils/teamListUtils.tsx
+++ b/app/utils/teamListUtils.tsx
@@ -11,9 +11,11 @@ export function shouldBeScored(teamList: Team[], team: Team, roundNumber: number
 }
 
 export function getNumberOfRounds(teams: Team[]): number {
-    return teams.reduce(
-        (acc: number, x: Team) => {
-            return x.eliminationOrder > acc && x.eliminationOrder !== Number.MAX_VALUE ? x.eliminationOrder : acc;
-        }, 0);
+    const seenOrders = new Set();
+    teams.forEach((t) => {
+        seenOrders.add(t.eliminationOrder);
+    });
+
+    return seenOrders.size;
 }
 

--- a/app/utils/teamListUtils.tsx
+++ b/app/utils/teamListUtils.tsx
@@ -12,7 +12,9 @@ export function shouldBeScored(teamList: Team[], team: Team, roundNumber: number
 
 export function getNumberOfRounds(teams: Team[]): number {
     const seenOrders = new Set();
-    teams.forEach((t) => {
+    teams.filter(
+        (t) => t.eliminationOrder !== Number.MAX_VALUE
+    ).forEach((t) => {
         seenOrders.add(t.eliminationOrder);
     });
 

--- a/app/utils/teamListUtils.tsx
+++ b/app/utils/teamListUtils.tsx
@@ -14,6 +14,7 @@ export function getNumberOfRounds(teams: Team[]): number {
     const seenOrders = new Set();
     teams.filter(
         (t) => t.eliminationOrder !== Number.MAX_VALUE
+            && t.eliminationOrder !== 0
     ).forEach((t) => {
         seenOrders.add(t.eliminationOrder);
     });


### PR DESCRIPTION
### Summary/Acceptance Criteria
After the introduction of the Fork in this season of Amazing race we are realizing that the number of rounds isn't necessarily based on the max of all the `eliminationOrder`s but instead is more like the number of unique `eliminationOrder`s

### Screenshots
N/A just changes how rounds are calculated

## Confirm
- [x] This PR has unit tests scenarios.
- [x] This PR is correctly linked to the relevant issue or milestone.
- [x] This PR has been locally QA'd.

/assign me