### PR TITLE
Feature/add regression tests

### DIFF
--- a/__tests__/models/LeagueStanding.js
+++ b/__tests__/models/LeagueStanding.js
@@ -379,7 +379,7 @@ describe("Regression Tests Checking Scoring of Archived Leagues", () => {
             return new Team(t);
         });
 
-        const numberOfRounds = 13;
+        const numberOfRounds = 15;
         const handicap = 0;
 
         // Act

--- a/__tests__/models/LeagueStanding.js
+++ b/__tests__/models/LeagueStanding.js
@@ -200,11 +200,15 @@ describe("Regression Tests Checking Scoring of Archived Leagues", () => {
         // Arrange
         const rachelsRawTeamList = [{"teamName":"Todd Martin & Ashlie Martin","relationship":"Married High School Sweethearts","isParticipating":false,"eliminationOrder":9},{"teamName":"Jocelyn Chao & Victor Limary","relationship":"Married Entrepreneurs","isParticipating":false,"eliminationOrder":3},{"teamName":"Joel Strasser & Garrett Smith","relationship":"Best Friends","isParticipating":false,"eliminationOrder":12.5},{"teamName":"Morgan Franklin & Lena Franklin","relationship":"Sisters","isParticipating":false,"eliminationOrder":7},{"teamName":"Joe Moskowitz & Ian Todd","relationship":"Engaged","isParticipating":false,"eliminationOrder":4},{"teamName":"Rob McArthur & Corey McArthur","relationship":"Father & Son","isParticipating":false,"eliminationOrder":11.5},{"teamName":"Greg Franklin & John Franklin","relationship":"Brothers & Computer Scientists","isParticipating":true,"eliminationOrder":0},{"teamName":"Liam Hykel & Yeremi Hykel","relationship":"Brothers","isParticipating":false,"eliminationOrder":5},{"teamName":"Steve Cargile & Anna Leigh Wilson","relationship":"Father & Daughter","isParticipating":false,"eliminationOrder":10},{"teamName":"Andrea Simpson & Malaina Hatcher","relationship":"College Friends","isParticipating":false,"eliminationOrder":6},{"teamName":"Robbin Tomich & Chelsea Day","relationship":"Childhood Friends","isParticipating":false,"eliminationOrder":8},{"teamName":"Elizabeth Rivera & Iliana Rivera","relationship":"Mother & Daughter","isParticipating":false,"eliminationOrder":2},{"teamName":"Alexandra Lichtor & Sheridan Lichtor","relationship":"Siblings & Roommates","isParticipating":false,"eliminationOrder":1}]
 
+        const rachelsParsedAndEmbelishedTeamList = rachelsRawTeamList.map(t => {
+            return new Team(t);
+        });
+
         const numberOfRounds = 13;
         const handicap = 0;
 
         // Act
-        const rachelsRoundScores = LeagueStanding.generateContestantRoundScores(rachelsRawTeamList, numberOfRounds, "testingRach", handicap);
+        const rachelsRoundScores = LeagueStanding.generateContestantRoundScores(rachelsParsedAndEmbelishedTeamList, numberOfRounds, "testingRach", handicap);
 
     });
 });

--- a/__tests__/models/LeagueStanding.js
+++ b/__tests__/models/LeagueStanding.js
@@ -210,5 +210,25 @@ describe("Regression Tests Checking Scoring of Archived Leagues", () => {
         // Act
         const rachelsRoundScores = LeagueStanding.generateContestantRoundScores(rachelsParsedAndEmbelishedTeamList, numberOfRounds, "testingRach", handicap);
 
+        // Assert
+        expect(rachelsRoundScores.length).toBe(numberOfRounds);
+
+
+        // Note: we are always pulling the 0th contestantRoundData because we
+        // are only inserting on contestant into the league
+        // round 0
+        expect(rachelsRoundScores[0].round).toBe(0);
+        expect(rachelsRoundScores[0].contestantRoundData[0].roundScore).toBe(120);
+        expect(rachelsRoundScores[0].contestantRoundData[0].totalScore).toBe(120);
+
+        // round 1
+        expect(rachelsRoundScores[1].round).toBe(1);
+        expect(rachelsRoundScores[1].contestantRoundData[0].roundScore).toBe(110);
+        expect(rachelsRoundScores[1].contestantRoundData[0].totalScore).toBe(230);
+
+        // round 2
+        expect(rachelsRoundScores[2].round).toBe(2);
+        expect(rachelsRoundScores[2].contestantRoundData[0].roundScore).toBe(90);
+        expect(rachelsRoundScores[2].contestantRoundData[0].totalScore).toBe(320);
     });
 });

--- a/__tests__/models/LeagueStanding.js
+++ b/__tests__/models/LeagueStanding.js
@@ -368,4 +368,11 @@ describe("Regression Tests Checking Scoring of Archived Leagues", () => {
         expect(anitasRoundScores[12].contestantRoundData[0].roundScore).toBe(0);
         expect(anitasRoundScores[12].contestantRoundData[0].totalScore).toBe(640);
     });
+
+    it("Should Score Sean correctly for Big Brother 26", () => {
+
+        // Arrange
+        const seansRawTeamList = [{"teamName":"Cam Sullivan-Brown","relationship":"Physical therapist","isParticipating":false,"eliminationOrder":14},{"teamName":"Joseph Rodriguez","relationship":"Video store clerk","isParticipating":false,"eliminationOrder":7},{"teamName":"Leah Peters","relationship":"VIP cocktail server","isParticipating":false,"eliminationOrder":10},{"teamName":"Brooklyn Rivera","relationship":"Business administrator","isParticipating":false,"eliminationOrder":5},{"teamName":"Kenney Kelley","relationship":"Former undercover cop","isParticipating":false,"eliminationOrder":3},{"teamName":"T'kor Clottey","relationship":"Crochet business owner","isParticipating":false,"eliminationOrder":9},{"teamName":"Cedric Hodges","relationship":"Former marine","isParticipating":false,"eliminationOrder":4},{"teamName":"Matt Hardeman","relationship":"Tech sales rep","isParticipating":false,"eliminationOrder":1},{"teamName":"Makensy Manbeck","relationship":"Construction project manager","isParticipating":false,"eliminationOrder":15},{"teamName":"Kimo Apaka","relationship":"Mattress sales representative","isParticipating":false,"eliminationOrder":12},{"teamName":"Tucker Des Lauriers","relationship":"Marketing/sales executive","isParticipating":false,"eliminationOrder":6},{"teamName":"Quinn Martin","relationship":"Nurse recruiter","isParticipating":false,"eliminationOrder":8},{"teamName":"Angela Murray","relationship":"Real estate agent","isParticipating":false,"eliminationOrder":11},{"teamName":"Rubina Bernabe","relationship":"Event bartender","isParticipating":false,"eliminationOrder":13},{"teamName":"Lisa Weintraub","relationship":"Celebrity chef","isParticipating":false,"eliminationOrder":2},{"teamName":"Chelsie Baham","relationship":"Nonprofit director","isParticipating":true,"eliminationOrder":1.7976931348623157e+308}]
+
+    });
 });

--- a/__tests__/models/LeagueStanding.js
+++ b/__tests__/models/LeagueStanding.js
@@ -281,4 +281,11 @@ describe("Regression Tests Checking Scoring of Archived Leagues", () => {
         expect(rachelsRoundScores[12].contestantRoundData[0].roundScore).toBe(0);
         expect(rachelsRoundScores[12].contestantRoundData[0].totalScore).toBe(560);
     });
+
+    it("Should Score Anita correctly for Amazing Race 36", () => {
+
+        // Arrange
+        const anitasRawTeamList = [{"teamName":"Rod Gardner & Leticia Gardner","relationship":"Married","isParticipating":false,"eliminationOrder":11.5},{"teamName":"Ricky Rotandi & Cesar Aldrete","relationship":"Boyfriends","isParticipating":true,"eliminationOrder":0},{"teamName":"Juan Villa & Shane Bilek","relationship":"Military Pilots","isParticipating":false,"eliminationOrder":12.5},{"teamName":"Sunny Pulver & Bizzy Smith","relationship":"Firefighter Moms","isParticipating":false,"eliminationOrder":7},{"teamName":"Derek Williams & Shelisa Williams","relationship":"Grandparents","isParticipating":false,"eliminationOrder":6},{"teamName":"Michelle Clark & Sean Clark","relationship":"Married Aerobics Instructors","isParticipating":false,"eliminationOrder":4},{"teamName":"Yvonne Chavez & Melissa Main","relationship":"Girlfriends","isParticipating":false,"eliminationOrder":9},{"teamName":"Kishori Turner & Karishma Cordero","relationship":"Cousins","isParticipating":false,"eliminationOrder":5},{"teamName":"Anthony Smith & Bailey Smith","relationship":"Twins","isParticipating":false,"eliminationOrder":3},{"teamName":"Angie Butler & Danny Butler","relationship":"Mother & Son","isParticipating":false,"eliminationOrder":8},{"teamName":"Amber Craven & Vinny Cagungun","relationship":"Dating Nurses","isParticipating":false,"eliminationOrder":10},{"teamName":"Chris Foster & Mary Cardona-Foster","relationship":"Father & Daughter","isParticipating":false,"eliminationOrder":2},{"teamName":"Maya Mody & Rohan Mody","relationship":"Siblings","isParticipating":false,"eliminationOrder":1}]
+
+    });
 });

--- a/__tests__/models/LeagueStanding.js
+++ b/__tests__/models/LeagueStanding.js
@@ -388,72 +388,81 @@ describe("Regression Tests Checking Scoring of Archived Leagues", () => {
         // Assert
         expect(seansRoundScores.length).toBe(numberOfRounds);
 
-
         // Note: we are always pulling the 0th contestantRoundData because we
         // are only inserting on contestant into the league
         // round 0
         expect(seansRoundScores[0].round).toBe(0);
-        expect(seansRoundScores[0].contestantRoundData[0].roundScore).toBe(120);
-        expect(seansRoundScores[0].contestantRoundData[0].totalScore).toBe(120);
+        expect(seansRoundScores[0].contestantRoundData[0].roundScore).toBe(140);
+        expect(seansRoundScores[0].contestantRoundData[0].totalScore).toBe(140);
 
         // round 1
         expect(seansRoundScores[1].round).toBe(1);
-        expect(seansRoundScores[1].contestantRoundData[0].roundScore).toBe(110);
-        expect(seansRoundScores[1].contestantRoundData[0].totalScore).toBe(230);
+        expect(seansRoundScores[1].contestantRoundData[0].roundScore).toBe(130);
+        expect(seansRoundScores[1].contestantRoundData[0].totalScore).toBe(270);
 
         // round 2
         expect(seansRoundScores[2].round).toBe(2);
-        expect(seansRoundScores[2].contestantRoundData[0].roundScore).toBe(90);
-        expect(seansRoundScores[2].contestantRoundData[0].totalScore).toBe(320);
+        expect(seansRoundScores[2].contestantRoundData[0].roundScore).toBe(110);
+        expect(seansRoundScores[2].contestantRoundData[0].totalScore).toBe(380);
 
         // round 3
         expect(seansRoundScores[3].round).toBe(3);
-        expect(seansRoundScores[3].contestantRoundData[0].roundScore).toBe(70);
-        expect(seansRoundScores[3].contestantRoundData[0].totalScore).toBe(390);
+        expect(seansRoundScores[3].contestantRoundData[0].roundScore).toBe(90);
+        expect(seansRoundScores[3].contestantRoundData[0].totalScore).toBe(470);
 
         // round 4
         expect(seansRoundScores[4].round).toBe(4);
-        expect(seansRoundScores[4].contestantRoundData[0].roundScore).toBe(60);
-        expect(seansRoundScores[4].contestantRoundData[0].totalScore).toBe(450);
+        expect(seansRoundScores[4].contestantRoundData[0].roundScore).toBe(70);
+        expect(seansRoundScores[4].contestantRoundData[0].totalScore).toBe(540);
 
         // round 5
         expect(seansRoundScores[5].round).toBe(5);
-        expect(seansRoundScores[5].contestantRoundData[0].roundScore).toBe(50);
-        expect(seansRoundScores[5].contestantRoundData[0].totalScore).toBe(500);
+        expect(seansRoundScores[5].contestantRoundData[0].roundScore).toBe(60);
+        expect(seansRoundScores[5].contestantRoundData[0].totalScore).toBe(600);
 
         // round 6
         expect(seansRoundScores[6].round).toBe(6);
-        expect(seansRoundScores[6].contestantRoundData[0].roundScore).toBe(30);
-        expect(seansRoundScores[6].contestantRoundData[0].totalScore).toBe(530);
+        expect(seansRoundScores[6].contestantRoundData[0].roundScore).toBe(40);
+        expect(seansRoundScores[6].contestantRoundData[0].totalScore).toBe(640);
 
         // round 7
         expect(seansRoundScores[7].round).toBe(7);
         expect(seansRoundScores[7].contestantRoundData[0].roundScore).toBe(30);
-        expect(seansRoundScores[7].contestantRoundData[0].totalScore).toBe(560);
+        expect(seansRoundScores[7].contestantRoundData[0].totalScore).toBe(670);
 
         // round 8
         expect(seansRoundScores[8].round).toBe(8);
-        expect(seansRoundScores[8].contestantRoundData[0].roundScore).toBe(30);
-        expect(seansRoundScores[8].contestantRoundData[0].totalScore).toBe(590);
+        expect(seansRoundScores[8].contestantRoundData[0].roundScore).toBe(20);
+        expect(seansRoundScores[8].contestantRoundData[0].totalScore).toBe(690);
 
         // round 9
         expect(seansRoundScores[9].round).toBe(9);
-        expect(seansRoundScores[9].contestantRoundData[0].roundScore).toBe(30);
-        expect(seansRoundScores[9].contestantRoundData[0].totalScore).toBe(620);
+        expect(seansRoundScores[9].contestantRoundData[0].roundScore).toBe(10);
+        expect(seansRoundScores[9].contestantRoundData[0].totalScore).toBe(700);
 
         // round 10
         expect(seansRoundScores[10].round).toBe(10);
-        expect(seansRoundScores[10].contestantRoundData[0].roundScore).toBe(20);
-        expect(seansRoundScores[10].contestantRoundData[0].totalScore).toBe(640);
+        expect(seansRoundScores[10].contestantRoundData[0].roundScore).toBe(10);
+        expect(seansRoundScores[10].contestantRoundData[0].totalScore).toBe(710);
 
         // round 11
         expect(seansRoundScores[11].round).toBe(11);
-        expect(seansRoundScores[11].contestantRoundData[0].roundScore).toBe(0);
-        expect(seansRoundScores[11].contestantRoundData[0].totalScore).toBe(640);
+        expect(seansRoundScores[11].contestantRoundData[0].roundScore).toBe(10);
+        expect(seansRoundScores[11].contestantRoundData[0].totalScore).toBe(720);
 
         // round 12
         expect(seansRoundScores[12].round).toBe(12);
-        expect(seansRoundScores[12].contestantRoundData[0].roundScore).toBe(0);
-        expect(seansRoundScores[12].contestantRoundData[0].totalScore).toBe(640);
+        expect(seansRoundScores[12].contestantRoundData[0].roundScore).toBe(10);
+        expect(seansRoundScores[12].contestantRoundData[0].totalScore).toBe(730);
+
+        // round 13
+        expect(seansRoundScores[13].round).toBe(13);
+        expect(seansRoundScores[13].contestantRoundData[0].roundScore).toBe(0);
+        expect(seansRoundScores[13].contestantRoundData[0].totalScore).toBe(730);
+
+        // round 14
+        expect(seansRoundScores[14].round).toBe(14);
+        expect(seansRoundScores[14].contestantRoundData[0].roundScore).toBe(0);
+        expect(seansRoundScores[14].contestantRoundData[0].totalScore).toBe(730);
     });
 });

--- a/__tests__/models/LeagueStanding.js
+++ b/__tests__/models/LeagueStanding.js
@@ -374,5 +374,86 @@ describe("Regression Tests Checking Scoring of Archived Leagues", () => {
         // Arrange
         const seansRawTeamList = [{"teamName":"Cam Sullivan-Brown","relationship":"Physical therapist","isParticipating":false,"eliminationOrder":14},{"teamName":"Joseph Rodriguez","relationship":"Video store clerk","isParticipating":false,"eliminationOrder":7},{"teamName":"Leah Peters","relationship":"VIP cocktail server","isParticipating":false,"eliminationOrder":10},{"teamName":"Brooklyn Rivera","relationship":"Business administrator","isParticipating":false,"eliminationOrder":5},{"teamName":"Kenney Kelley","relationship":"Former undercover cop","isParticipating":false,"eliminationOrder":3},{"teamName":"T'kor Clottey","relationship":"Crochet business owner","isParticipating":false,"eliminationOrder":9},{"teamName":"Cedric Hodges","relationship":"Former marine","isParticipating":false,"eliminationOrder":4},{"teamName":"Matt Hardeman","relationship":"Tech sales rep","isParticipating":false,"eliminationOrder":1},{"teamName":"Makensy Manbeck","relationship":"Construction project manager","isParticipating":false,"eliminationOrder":15},{"teamName":"Kimo Apaka","relationship":"Mattress sales representative","isParticipating":false,"eliminationOrder":12},{"teamName":"Tucker Des Lauriers","relationship":"Marketing/sales executive","isParticipating":false,"eliminationOrder":6},{"teamName":"Quinn Martin","relationship":"Nurse recruiter","isParticipating":false,"eliminationOrder":8},{"teamName":"Angela Murray","relationship":"Real estate agent","isParticipating":false,"eliminationOrder":11},{"teamName":"Rubina Bernabe","relationship":"Event bartender","isParticipating":false,"eliminationOrder":13},{"teamName":"Lisa Weintraub","relationship":"Celebrity chef","isParticipating":false,"eliminationOrder":2},{"teamName":"Chelsie Baham","relationship":"Nonprofit director","isParticipating":true,"eliminationOrder":1.7976931348623157e+308}]
 
+
+        const seansParsedAndEmbelishedTeamList = seansRawTeamList.map(t => {
+            return new Team(t);
+        });
+
+        const numberOfRounds = 13;
+        const handicap = 0;
+
+        // Act
+        const seansRoundScores = LeagueStanding.generateContestantRoundScores(seansParsedAndEmbelishedTeamList, numberOfRounds, "testingSean", handicap);
+
+        // Assert
+        expect(seansRoundScores.length).toBe(numberOfRounds);
+
+
+        // Note: we are always pulling the 0th contestantRoundData because we
+        // are only inserting on contestant into the league
+        // round 0
+        expect(seansRoundScores[0].round).toBe(0);
+        expect(seansRoundScores[0].contestantRoundData[0].roundScore).toBe(120);
+        expect(seansRoundScores[0].contestantRoundData[0].totalScore).toBe(120);
+
+        // round 1
+        expect(seansRoundScores[1].round).toBe(1);
+        expect(seansRoundScores[1].contestantRoundData[0].roundScore).toBe(110);
+        expect(seansRoundScores[1].contestantRoundData[0].totalScore).toBe(230);
+
+        // round 2
+        expect(seansRoundScores[2].round).toBe(2);
+        expect(seansRoundScores[2].contestantRoundData[0].roundScore).toBe(90);
+        expect(seansRoundScores[2].contestantRoundData[0].totalScore).toBe(320);
+
+        // round 3
+        expect(seansRoundScores[3].round).toBe(3);
+        expect(seansRoundScores[3].contestantRoundData[0].roundScore).toBe(70);
+        expect(seansRoundScores[3].contestantRoundData[0].totalScore).toBe(390);
+
+        // round 4
+        expect(seansRoundScores[4].round).toBe(4);
+        expect(seansRoundScores[4].contestantRoundData[0].roundScore).toBe(60);
+        expect(seansRoundScores[4].contestantRoundData[0].totalScore).toBe(450);
+
+        // round 5
+        expect(seansRoundScores[5].round).toBe(5);
+        expect(seansRoundScores[5].contestantRoundData[0].roundScore).toBe(50);
+        expect(seansRoundScores[5].contestantRoundData[0].totalScore).toBe(500);
+
+        // round 6
+        expect(seansRoundScores[6].round).toBe(6);
+        expect(seansRoundScores[6].contestantRoundData[0].roundScore).toBe(30);
+        expect(seansRoundScores[6].contestantRoundData[0].totalScore).toBe(530);
+
+        // round 7
+        expect(seansRoundScores[7].round).toBe(7);
+        expect(seansRoundScores[7].contestantRoundData[0].roundScore).toBe(30);
+        expect(seansRoundScores[7].contestantRoundData[0].totalScore).toBe(560);
+
+        // round 8
+        expect(seansRoundScores[8].round).toBe(8);
+        expect(seansRoundScores[8].contestantRoundData[0].roundScore).toBe(30);
+        expect(seansRoundScores[8].contestantRoundData[0].totalScore).toBe(590);
+
+        // round 9
+        expect(seansRoundScores[9].round).toBe(9);
+        expect(seansRoundScores[9].contestantRoundData[0].roundScore).toBe(30);
+        expect(seansRoundScores[9].contestantRoundData[0].totalScore).toBe(620);
+
+        // round 10
+        expect(seansRoundScores[10].round).toBe(10);
+        expect(seansRoundScores[10].contestantRoundData[0].roundScore).toBe(20);
+        expect(seansRoundScores[10].contestantRoundData[0].totalScore).toBe(640);
+
+        // round 11
+        expect(seansRoundScores[11].round).toBe(11);
+        expect(seansRoundScores[11].contestantRoundData[0].roundScore).toBe(0);
+        expect(seansRoundScores[11].contestantRoundData[0].totalScore).toBe(640);
+
+        // round 12
+        expect(seansRoundScores[12].round).toBe(12);
+        expect(seansRoundScores[12].contestantRoundData[0].roundScore).toBe(0);
+        expect(seansRoundScores[12].contestantRoundData[0].totalScore).toBe(640);
     });
 });

--- a/__tests__/models/LeagueStanding.js
+++ b/__tests__/models/LeagueStanding.js
@@ -287,5 +287,85 @@ describe("Regression Tests Checking Scoring of Archived Leagues", () => {
         // Arrange
         const anitasRawTeamList = [{"teamName":"Rod Gardner & Leticia Gardner","relationship":"Married","isParticipating":false,"eliminationOrder":11.5},{"teamName":"Ricky Rotandi & Cesar Aldrete","relationship":"Boyfriends","isParticipating":true,"eliminationOrder":0},{"teamName":"Juan Villa & Shane Bilek","relationship":"Military Pilots","isParticipating":false,"eliminationOrder":12.5},{"teamName":"Sunny Pulver & Bizzy Smith","relationship":"Firefighter Moms","isParticipating":false,"eliminationOrder":7},{"teamName":"Derek Williams & Shelisa Williams","relationship":"Grandparents","isParticipating":false,"eliminationOrder":6},{"teamName":"Michelle Clark & Sean Clark","relationship":"Married Aerobics Instructors","isParticipating":false,"eliminationOrder":4},{"teamName":"Yvonne Chavez & Melissa Main","relationship":"Girlfriends","isParticipating":false,"eliminationOrder":9},{"teamName":"Kishori Turner & Karishma Cordero","relationship":"Cousins","isParticipating":false,"eliminationOrder":5},{"teamName":"Anthony Smith & Bailey Smith","relationship":"Twins","isParticipating":false,"eliminationOrder":3},{"teamName":"Angie Butler & Danny Butler","relationship":"Mother & Son","isParticipating":false,"eliminationOrder":8},{"teamName":"Amber Craven & Vinny Cagungun","relationship":"Dating Nurses","isParticipating":false,"eliminationOrder":10},{"teamName":"Chris Foster & Mary Cardona-Foster","relationship":"Father & Daughter","isParticipating":false,"eliminationOrder":2},{"teamName":"Maya Mody & Rohan Mody","relationship":"Siblings","isParticipating":false,"eliminationOrder":1}]
 
+        const anitasParsedAndEmbelishedTeamList = anitasRawTeamList.map(t => {
+            return new Team(t);
+        });
+
+        const numberOfRounds = 13;
+        const handicap = 0;
+
+        // Act
+        const anitasRoundScores = LeagueStanding.generateContestantRoundScores(anitasParsedAndEmbelishedTeamList, numberOfRounds, "testingAnita", handicap);
+
+        // Assert
+        expect(anitasRoundScores.length).toBe(numberOfRounds);
+
+
+        // Note: we are always pulling the 0th contestantRoundData because we
+        // are only inserting on contestant into the league
+        // round 0
+        expect(anitasRoundScores[0].round).toBe(0);
+        expect(anitasRoundScores[0].contestantRoundData[0].roundScore).toBe(120);
+        expect(anitasRoundScores[0].contestantRoundData[0].totalScore).toBe(120);
+
+        // round 1
+        expect(anitasRoundScores[1].round).toBe(1);
+        expect(anitasRoundScores[1].contestantRoundData[0].roundScore).toBe(110);
+        expect(anitasRoundScores[1].contestantRoundData[0].totalScore).toBe(230);
+
+        // round 2
+        expect(anitasRoundScores[2].round).toBe(2);
+        expect(anitasRoundScores[2].contestantRoundData[0].roundScore).toBe(90);
+        expect(anitasRoundScores[2].contestantRoundData[0].totalScore).toBe(320);
+
+        // round 3
+        expect(anitasRoundScores[3].round).toBe(3);
+        expect(anitasRoundScores[3].contestantRoundData[0].roundScore).toBe(70);
+        expect(anitasRoundScores[3].contestantRoundData[0].totalScore).toBe(390);
+
+        // round 4
+        expect(anitasRoundScores[4].round).toBe(4);
+        expect(anitasRoundScores[4].contestantRoundData[0].roundScore).toBe(50);
+        expect(anitasRoundScores[4].contestantRoundData[0].totalScore).toBe(440);
+
+        // round 5
+        expect(anitasRoundScores[5].round).toBe(5);
+        expect(anitasRoundScores[5].contestantRoundData[0].roundScore).toBe(50);
+        expect(anitasRoundScores[5].contestantRoundData[0].totalScore).toBe(490);
+
+        // round 6
+        expect(anitasRoundScores[6].round).toBe(6);
+        expect(anitasRoundScores[6].contestantRoundData[0].roundScore).toBe(30);
+        expect(anitasRoundScores[6].contestantRoundData[0].totalScore).toBe(520);
+
+        // round 7
+        expect(anitasRoundScores[7].round).toBe(7);
+        expect(anitasRoundScores[7].contestantRoundData[0].roundScore).toBe(20);
+        expect(anitasRoundScores[7].contestantRoundData[0].totalScore).toBe(540);
+
+        // round 8
+        expect(anitasRoundScores[8].round).toBe(8);
+        expect(anitasRoundScores[8].contestantRoundData[0].roundScore).toBe(10);
+        expect(anitasRoundScores[8].contestantRoundData[0].totalScore).toBe(550);
+
+        // round 9
+        expect(anitasRoundScores[9].round).toBe(9);
+        expect(anitasRoundScores[9].contestantRoundData[0].roundScore).toBe(10);
+        expect(anitasRoundScores[9].contestantRoundData[0].totalScore).toBe(560);
+
+        // round 10
+        expect(anitasRoundScores[10].round).toBe(10);
+        expect(anitasRoundScores[10].contestantRoundData[0].roundScore).toBe(0);
+        expect(anitasRoundScores[10].contestantRoundData[0].totalScore).toBe(560);
+
+        // round 11
+        expect(anitasRoundScores[11].round).toBe(11);
+        expect(anitasRoundScores[11].contestantRoundData[0].roundScore).toBe(0);
+        expect(anitasRoundScores[11].contestantRoundData[0].totalScore).toBe(560);
+
+        // round 12
+        expect(anitasRoundScores[12].round).toBe(12);
+        expect(anitasRoundScores[12].contestantRoundData[0].roundScore).toBe(0);
+        expect(anitasRoundScores[12].contestantRoundData[0].totalScore).toBe(560);
     });
 });

--- a/__tests__/models/LeagueStanding.js
+++ b/__tests__/models/LeagueStanding.js
@@ -192,3 +192,9 @@ describe("addContestantRoundScores", () => {
         expect(resultingContestantRoundData[0].totalScore).toBe(10);
     });
 });
+
+describe("Regression Tests Checking Scoring of Archived Leagues", () => {
+
+    it("");
+
+});

--- a/__tests__/models/LeagueStanding.js
+++ b/__tests__/models/LeagueStanding.js
@@ -195,6 +195,16 @@ describe("addContestantRoundScores", () => {
 
 describe("Regression Tests Checking Scoring of Archived Leagues", () => {
 
-    it("");
+    it("Should Score Rachel correctly for Amazing Race 35", () => {
 
+        // Arrange
+        const rachelsRawTeamList = [{"teamName":"Todd Martin & Ashlie Martin","relationship":"Married High School Sweethearts","isParticipating":false,"eliminationOrder":9},{"teamName":"Jocelyn Chao & Victor Limary","relationship":"Married Entrepreneurs","isParticipating":false,"eliminationOrder":3},{"teamName":"Joel Strasser & Garrett Smith","relationship":"Best Friends","isParticipating":false,"eliminationOrder":12.5},{"teamName":"Morgan Franklin & Lena Franklin","relationship":"Sisters","isParticipating":false,"eliminationOrder":7},{"teamName":"Joe Moskowitz & Ian Todd","relationship":"Engaged","isParticipating":false,"eliminationOrder":4},{"teamName":"Rob McArthur & Corey McArthur","relationship":"Father & Son","isParticipating":false,"eliminationOrder":11.5},{"teamName":"Greg Franklin & John Franklin","relationship":"Brothers & Computer Scientists","isParticipating":true,"eliminationOrder":0},{"teamName":"Liam Hykel & Yeremi Hykel","relationship":"Brothers","isParticipating":false,"eliminationOrder":5},{"teamName":"Steve Cargile & Anna Leigh Wilson","relationship":"Father & Daughter","isParticipating":false,"eliminationOrder":10},{"teamName":"Andrea Simpson & Malaina Hatcher","relationship":"College Friends","isParticipating":false,"eliminationOrder":6},{"teamName":"Robbin Tomich & Chelsea Day","relationship":"Childhood Friends","isParticipating":false,"eliminationOrder":8},{"teamName":"Elizabeth Rivera & Iliana Rivera","relationship":"Mother & Daughter","isParticipating":false,"eliminationOrder":2},{"teamName":"Alexandra Lichtor & Sheridan Lichtor","relationship":"Siblings & Roommates","isParticipating":false,"eliminationOrder":1}]
+
+        const numberOfRounds = 13;
+        const handicap = 0;
+
+        // Act
+        const rachelsRoundScores = LeagueStanding.generateContestantRoundScores(rachelsRawTeamList, numberOfRounds, "testingRach", handicap);
+
+    });
 });

--- a/__tests__/models/LeagueStanding.js
+++ b/__tests__/models/LeagueStanding.js
@@ -325,47 +325,47 @@ describe("Regression Tests Checking Scoring of Archived Leagues", () => {
 
         // round 4
         expect(anitasRoundScores[4].round).toBe(4);
-        expect(anitasRoundScores[4].contestantRoundData[0].roundScore).toBe(50);
-        expect(anitasRoundScores[4].contestantRoundData[0].totalScore).toBe(440);
+        expect(anitasRoundScores[4].contestantRoundData[0].roundScore).toBe(60);
+        expect(anitasRoundScores[4].contestantRoundData[0].totalScore).toBe(450);
 
         // round 5
         expect(anitasRoundScores[5].round).toBe(5);
         expect(anitasRoundScores[5].contestantRoundData[0].roundScore).toBe(50);
-        expect(anitasRoundScores[5].contestantRoundData[0].totalScore).toBe(490);
+        expect(anitasRoundScores[5].contestantRoundData[0].totalScore).toBe(500);
 
         // round 6
         expect(anitasRoundScores[6].round).toBe(6);
         expect(anitasRoundScores[6].contestantRoundData[0].roundScore).toBe(30);
-        expect(anitasRoundScores[6].contestantRoundData[0].totalScore).toBe(520);
+        expect(anitasRoundScores[6].contestantRoundData[0].totalScore).toBe(530);
 
         // round 7
         expect(anitasRoundScores[7].round).toBe(7);
-        expect(anitasRoundScores[7].contestantRoundData[0].roundScore).toBe(20);
-        expect(anitasRoundScores[7].contestantRoundData[0].totalScore).toBe(540);
+        expect(anitasRoundScores[7].contestantRoundData[0].roundScore).toBe(30);
+        expect(anitasRoundScores[7].contestantRoundData[0].totalScore).toBe(560);
 
         // round 8
         expect(anitasRoundScores[8].round).toBe(8);
-        expect(anitasRoundScores[8].contestantRoundData[0].roundScore).toBe(10);
-        expect(anitasRoundScores[8].contestantRoundData[0].totalScore).toBe(550);
+        expect(anitasRoundScores[8].contestantRoundData[0].roundScore).toBe(30);
+        expect(anitasRoundScores[8].contestantRoundData[0].totalScore).toBe(590);
 
         // round 9
         expect(anitasRoundScores[9].round).toBe(9);
-        expect(anitasRoundScores[9].contestantRoundData[0].roundScore).toBe(10);
-        expect(anitasRoundScores[9].contestantRoundData[0].totalScore).toBe(560);
+        expect(anitasRoundScores[9].contestantRoundData[0].roundScore).toBe(30);
+        expect(anitasRoundScores[9].contestantRoundData[0].totalScore).toBe(620);
 
         // round 10
         expect(anitasRoundScores[10].round).toBe(10);
-        expect(anitasRoundScores[10].contestantRoundData[0].roundScore).toBe(0);
-        expect(anitasRoundScores[10].contestantRoundData[0].totalScore).toBe(560);
+        expect(anitasRoundScores[10].contestantRoundData[0].roundScore).toBe(20);
+        expect(anitasRoundScores[10].contestantRoundData[0].totalScore).toBe(640);
 
         // round 11
         expect(anitasRoundScores[11].round).toBe(11);
         expect(anitasRoundScores[11].contestantRoundData[0].roundScore).toBe(0);
-        expect(anitasRoundScores[11].contestantRoundData[0].totalScore).toBe(560);
+        expect(anitasRoundScores[11].contestantRoundData[0].totalScore).toBe(640);
 
         // round 12
         expect(anitasRoundScores[12].round).toBe(12);
         expect(anitasRoundScores[12].contestantRoundData[0].roundScore).toBe(0);
-        expect(anitasRoundScores[12].contestantRoundData[0].totalScore).toBe(560);
+        expect(anitasRoundScores[12].contestantRoundData[0].totalScore).toBe(640);
     });
 });

--- a/__tests__/models/LeagueStanding.js
+++ b/__tests__/models/LeagueStanding.js
@@ -230,5 +230,55 @@ describe("Regression Tests Checking Scoring of Archived Leagues", () => {
         expect(rachelsRoundScores[2].round).toBe(2);
         expect(rachelsRoundScores[2].contestantRoundData[0].roundScore).toBe(90);
         expect(rachelsRoundScores[2].contestantRoundData[0].totalScore).toBe(320);
+
+        // round 3
+        expect(rachelsRoundScores[3].round).toBe(3);
+        expect(rachelsRoundScores[3].contestantRoundData[0].roundScore).toBe(70);
+        expect(rachelsRoundScores[3].contestantRoundData[0].totalScore).toBe(390);
+
+        // round 4
+        expect(rachelsRoundScores[4].round).toBe(4);
+        expect(rachelsRoundScores[4].contestantRoundData[0].roundScore).toBe(50);
+        expect(rachelsRoundScores[4].contestantRoundData[0].totalScore).toBe(440);
+
+        // round 5
+        expect(rachelsRoundScores[5].round).toBe(5);
+        expect(rachelsRoundScores[5].contestantRoundData[0].roundScore).toBe(50);
+        expect(rachelsRoundScores[5].contestantRoundData[0].totalScore).toBe(490);
+
+        // round 6
+        expect(rachelsRoundScores[6].round).toBe(6);
+        expect(rachelsRoundScores[6].contestantRoundData[0].roundScore).toBe(30);
+        expect(rachelsRoundScores[6].contestantRoundData[0].totalScore).toBe(520);
+
+        // round 7
+        expect(rachelsRoundScores[7].round).toBe(7);
+        expect(rachelsRoundScores[7].contestantRoundData[0].roundScore).toBe(20);
+        expect(rachelsRoundScores[7].contestantRoundData[0].totalScore).toBe(540);
+
+        // round 8
+        expect(rachelsRoundScores[8].round).toBe(8);
+        expect(rachelsRoundScores[8].contestantRoundData[0].roundScore).toBe(10);
+        expect(rachelsRoundScores[8].contestantRoundData[0].totalScore).toBe(550);
+
+        // round 9
+        expect(rachelsRoundScores[9].round).toBe(9);
+        expect(rachelsRoundScores[9].contestantRoundData[0].roundScore).toBe(10);
+        expect(rachelsRoundScores[9].contestantRoundData[0].totalScore).toBe(560);
+
+        // round 10
+        expect(rachelsRoundScores[10].round).toBe(10);
+        expect(rachelsRoundScores[10].contestantRoundData[0].roundScore).toBe(0);
+        expect(rachelsRoundScores[10].contestantRoundData[0].totalScore).toBe(560);
+
+        // round 11
+        expect(rachelsRoundScores[11].round).toBe(11);
+        expect(rachelsRoundScores[11].contestantRoundData[0].roundScore).toBe(0);
+        expect(rachelsRoundScores[11].contestantRoundData[0].totalScore).toBe(560);
+
+        // round 12
+        expect(rachelsRoundScores[12].round).toBe(12);
+        expect(rachelsRoundScores[12].contestantRoundData[0].roundScore).toBe(0);
+        expect(rachelsRoundScores[12].contestantRoundData[0].totalScore).toBe(560);
     });
 });


### PR DESCRIPTION
### Summary/Acceptance Criteria
As per our discussion we talked about adding at least one test per archived league so that we could use those as a sense of regression as we change our scoring algorithm. Here are 3 such tests.

### Screenshots
N/A No behavior change, just adding tests

## Confirm
- [x] This PR has unit tests scenarios. (This is tests 😆)
- [x] This PR is correctly linked to the relevant issue or milestone.
- [x] This PR has been locally QA'd. (tests pass)

/assign me