### PR TITLE
228 a teams response to isinplay cannot based on round

### DIFF
--- a/__tests__/models/League.js
+++ b/__tests__/models/League.js
@@ -355,18 +355,18 @@ describe("Regression Tests Checking Scoring of Archived Leagues", () => {
 
         // round 10
         expect(anitasRoundScores[10].round).toBe(10);
-        expect(anitasRoundScores[10].contestantRoundData[0].roundScore).toBe(20);
-        expect(anitasRoundScores[10].contestantRoundData[0].totalScore).toBe(640);
+        expect(anitasRoundScores[10].contestantRoundData[0].roundScore).toBe(10);
+        expect(anitasRoundScores[10].contestantRoundData[0].totalScore).toBe(630);
 
         // round 11
         expect(anitasRoundScores[11].round).toBe(11);
         expect(anitasRoundScores[11].contestantRoundData[0].roundScore).toBe(0);
-        expect(anitasRoundScores[11].contestantRoundData[0].totalScore).toBe(640);
+        expect(anitasRoundScores[11].contestantRoundData[0].totalScore).toBe(630);
 
         // round 12
         expect(anitasRoundScores[12].round).toBe(12);
         expect(anitasRoundScores[12].contestantRoundData[0].roundScore).toBe(0);
-        expect(anitasRoundScores[12].contestantRoundData[0].totalScore).toBe(640);
+        expect(anitasRoundScores[12].contestantRoundData[0].totalScore).toBe(630);
     });
 
     it("Should Score Sean correctly for Big Brother 26", () => {

--- a/__tests__/utils/teamListUtils.js
+++ b/__tests__/utils/teamListUtils.js
@@ -1,4 +1,4 @@
-import { shouldBeScored, getNumberOfRounds } from "../../app/utils/teamListUtils";
+import { shouldBeScored, getUniqueEliminationOrders, getNumberOfRounds } from "../../app/utils/teamListUtils";
 
 describe("teamListUtils shouldBeScored", () => {
     it("should be false when there is exactly one team and we are on the first round", () => {

--- a/__tests__/utils/teamListUtils.js
+++ b/__tests__/utils/teamListUtils.js
@@ -76,6 +76,21 @@ describe("teamListUtils shouldBeScored", () => {
         // Assert
         expect(aTeam.isInPlay).toHaveBeenCalledWith(1);
     });
+
+    it("Should be able to determine the find the appropriate eliminationOrder after a multi elimination round", () => {
+        // Arrange
+        const aTeam = {
+            isInPlay: jest.fn(),
+            eliminationOrder: 3
+        };
+        const teamList = [aTeam, { eliminationOrder: 1 }, { eliminationOrder: 1 }];
+
+        // Act
+        shouldBeScored(teamList, aTeam, 1); // this is round 2, by 0 indexing
+
+        // Assert
+        expect(aTeam.isInPlay).toHaveBeenCalledWith(3);
+    });
 });
 
 describe("getNumberOfRounds", () => {

--- a/__tests__/utils/teamListUtils.js
+++ b/__tests__/utils/teamListUtils.js
@@ -95,6 +95,19 @@ describe("teamListUtils shouldBeScored", () => {
 
 describe("getUniqueEliminationOrders", () => {
     it("Should include even teams with partial eliminationOrders", () => {
+        // Arrange
+        const partialEliminationOrder = 12.5;
+        const aTeam = {
+            isInPlay: jest.fn(),
+            eliminationOrder: partialEliminationOrder
+        };
+        const teamList = [aTeam, { eliminationOrder: 1 }, { eliminationOrder: 1 }];
+
+        // Act
+        const result = getUniqueEliminationOrders(teamList);
+
+        // Assert
+        expect(result).toContain(partialEliminationOrder);
     });
 });
 

--- a/__tests__/utils/teamListUtils.js
+++ b/__tests__/utils/teamListUtils.js
@@ -93,6 +93,11 @@ describe("teamListUtils shouldBeScored", () => {
     });
 });
 
+describe("getUniqueEliminationOrders", () => {
+    it("Should include even teams with partial eliminationOrders", () => {
+    });
+});
+
 describe("getNumberOfRounds", () => {
     it("should not ever return Number.MAX_VALUE", () => {
         //Arrange

--- a/__tests__/utils/teamListUtils.js
+++ b/__tests__/utils/teamListUtils.js
@@ -61,6 +61,21 @@ describe("teamListUtils shouldBeScored", () => {
         // Assert
         expect(result).toBeTruthy();
     });
+
+    it("Should be able to determine the round even with eliminationOrder being 1 indexed", () => {
+        // Arrange
+        const aTeam = {
+            isInPlay: jest.fn(),
+            eliminationOrder: 1
+        };
+        const teamList = [aTeam, {}];
+
+        // Act
+        shouldBeScored(teamList, aTeam, 0);
+
+        // Assert
+        expect(aTeam.isInPlay).toHaveBeenCalledWith(1);
+    });
 });
 
 describe("getNumberOfRounds", () => {

--- a/app/utils/teamListUtils.tsx
+++ b/app/utils/teamListUtils.tsx
@@ -11,7 +11,11 @@ export function shouldBeScored(teamList: Team[], team: Team, roundNumber: number
     const currentWeek = roundNumber+1;
     const listHasTeamBeingEliminated = teamPosition <= currentWeek;
 
-    return team.isInPlay(currentWeek) && !listHasTeamBeingEliminated;
+    const roundElimMapping = getRoundEliminationOrderMapping(teamList);
+
+    const elimOrder = roundElimMapping[roundNumber];
+
+    return team.isInPlay(elimOrder) && !listHasTeamBeingEliminated;
 }
 
 function getRoundEliminationOrderMapping(teamList: Team[]): RoundEliminationOrderMapping {

--- a/app/utils/teamListUtils.tsx
+++ b/app/utils/teamListUtils.tsx
@@ -14,7 +14,7 @@ export function shouldBeScored(teamList: Team[], team: Team, roundNumber: number
     return team.isInPlay(currentWeek) && !listHasTeamBeingEliminated;
 }
 
-function getRoundEliminationOrderMapping(teamList: Team[]): any {
+function getRoundEliminationOrderMapping(teamList: Team[]): RoundEliminationOrderMapping {
 
     const setOfEliminationOrders = getUniqueEliminationOrders(teamList);
     const listOfEliminationOrders = Array.from(setOfEliminationOrders)

--- a/app/utils/teamListUtils.tsx
+++ b/app/utils/teamListUtils.tsx
@@ -1,5 +1,9 @@
 import Team from "../models/Team";
 
+interface RoundEliminationOrderMapping {
+    [Key: string]: number;
+}
+
 export function shouldBeScored(teamList: Team[], team: Team, roundNumber: number): boolean {
 
     const teamPosition = teamList.length - teamList.indexOf(team);

--- a/app/utils/teamListUtils.tsx
+++ b/app/utils/teamListUtils.tsx
@@ -20,7 +20,7 @@ function getRoundEliminationOrderMapping(teamList: Team[]): RoundEliminationOrde
     const listOfEliminationOrders = Array.from(setOfEliminationOrders)
     listOfEliminationOrders.sort((x, y) => Number(x) - Number(y));
 
-    const mapping = {};
+    const mapping: RoundEliminationOrderMapping = {};
     listOfEliminationOrders.forEach((t, i) => {
         mapping[i] = Number(t);
     });

--- a/app/utils/teamListUtils.tsx
+++ b/app/utils/teamListUtils.tsx
@@ -10,8 +10,8 @@ export function shouldBeScored(teamList: Team[], team: Team, roundNumber: number
     return team.isInPlay(currentWeek) && !listHasTeamBeingEliminated;
 }
 
-function getUniqueEliminationOrders(teams: Team[]): Set {
-    const seenOrders = new Set();
+function getUniqueEliminationOrders(teams: Team[]): Set<number> {
+    const seenOrders = new Set<number>();
     teams.filter(
         (t) => t.eliminationOrder !== Number.MAX_VALUE
             && t.eliminationOrder !== 0

--- a/app/utils/teamListUtils.tsx
+++ b/app/utils/teamListUtils.tsx
@@ -32,7 +32,7 @@ function getRoundEliminationOrderMapping(teamList: Team[]): RoundEliminationOrde
     return mapping;
 }
 
-function getUniqueEliminationOrders(teams: Team[]): Set<number> {
+export function getUniqueEliminationOrders(teams: Team[]): Set<number> {
     const seenOrders = new Set<number>();
     teams.filter(
         (t) => t.eliminationOrder !== Number.MAX_VALUE

--- a/app/utils/teamListUtils.tsx
+++ b/app/utils/teamListUtils.tsx
@@ -10,6 +10,20 @@ export function shouldBeScored(teamList: Team[], team: Team, roundNumber: number
     return team.isInPlay(currentWeek) && !listHasTeamBeingEliminated;
 }
 
+function getRoundEliminationOrderMapping(teamList: Team[]): any {
+
+    const setOfEliminationOrders = getUniqueEliminationOrders(teamList);
+    const listOfEliminationOrders = Array.from(setOfEliminationOrders)
+    listOfEliminationOrders.sort((x, y) => x - y);
+
+    const mapping = {};
+    listOfEliminationOrders.forEach((t, i) => {
+        mapping[i] = t;
+    });
+
+    return mapping;
+}
+
 function getUniqueEliminationOrders(teams: Team[]): Set<number> {
     const seenOrders = new Set<number>();
     teams.filter(

--- a/app/utils/teamListUtils.tsx
+++ b/app/utils/teamListUtils.tsx
@@ -22,7 +22,7 @@ function getRoundEliminationOrderMapping(teamList: Team[]): RoundEliminationOrde
 
     const mapping = {};
     listOfEliminationOrders.forEach((t, i) => {
-        mapping[i] = t;
+        mapping[i] = Number(t);
     });
 
     return mapping;

--- a/app/utils/teamListUtils.tsx
+++ b/app/utils/teamListUtils.tsx
@@ -14,7 +14,7 @@ function getRoundEliminationOrderMapping(teamList: Team[]): any {
 
     const setOfEliminationOrders = getUniqueEliminationOrders(teamList);
     const listOfEliminationOrders = Array.from(setOfEliminationOrders)
-    listOfEliminationOrders.sort((x, y) => x - y);
+    listOfEliminationOrders.sort((x, y) => Number(x) - Number(y));
 
     const mapping = {};
     listOfEliminationOrders.forEach((t, i) => {

--- a/app/utils/teamListUtils.tsx
+++ b/app/utils/teamListUtils.tsx
@@ -10,7 +10,7 @@ export function shouldBeScored(teamList: Team[], team: Team, roundNumber: number
     return team.isInPlay(currentWeek) && !listHasTeamBeingEliminated;
 }
 
-export function getNumberOfRounds(teams: Team[]): number {
+function getUniqueEliminationOrders(teams: Team[]): Set {
     const seenOrders = new Set();
     teams.filter(
         (t) => t.eliminationOrder !== Number.MAX_VALUE
@@ -18,6 +18,11 @@ export function getNumberOfRounds(teams: Team[]): number {
     ).forEach((t) => {
         seenOrders.add(t.eliminationOrder);
     });
+    return seenOrders;
+}
+
+export function getNumberOfRounds(teams: Team[]): number {
+    const seenOrders = getUniqueEliminationOrders(teams);
 
     return seenOrders.size;
 }


### PR DESCRIPTION
### Summary/Acceptance Criteria
Just as it appears, this should solve the issue where a team is currently checked to see if it is in pay using round number which was already very loosely true. This address that by creating  a mapping between eliminationOrder and league round. 

#### Things To Note
- This does run _a lot_ likely runs at least for every team * the number of rounds * the number of leagueContestants. There is definitely a way to optimize, but this does at least work. (did a rough count and got ~1400 calls). Having said all this I think the idea is we would like this work to be memoized in an object a level up, the `League` object. and so that will come when we are resolving #229 
- After making this change one of our "regression tests" failed and upon further reflection it looks like it should have never worked that way. Looks like `Rod & Leticia` got eliminated in one position, but that does not necessarily translate to the correct elimination order when scoring and crossing teams off.

### Screenshots

#### Before

<img width="730" alt="image" src="https://github.com/user-attachments/assets/70bc1f97-2f70-4beb-9586-ea75b8903ca1" />

#### After

<img width="724" alt="image" src="https://github.com/user-attachments/assets/a88f0dc0-e2c1-4df9-9dbd-47749f4cefdb" />

#### Bug Pictures

##### Before

<img width="736" alt="image" src="https://github.com/user-attachments/assets/6cabc2ef-1643-4db9-b795-b5bbf9e518a9" />

##### After

<img width="759" alt="image" src="https://github.com/user-attachments/assets/fc72a9dc-1387-4538-9774-ae9260a892d3" />


## Confirm
- [x] This PR has unit tests scenarios. (added a few new tests for new behavior as well as a small test to check for the condition that lead to the bug in Amazing Race 36 pointed out in the screenshots)
- [x] This PR is correctly linked to the relevant issue or milestone.
- [x] This PR has been locally QA'd.
- [ ] This PR has had it's db migrations run. (N/A no new data here)

/assign me
