### PR TITLE
Feature/insert teamdata into league

### DIFF
--- a/__tests__/models/League.js
+++ b/__tests__/models/League.js
@@ -193,6 +193,68 @@ describe("addContestantRoundScores", () => {
     });
 });
 
+describe("getNumberOfRounds", () => {
+    it("should not ever return Number.MAX_VALUE", () => {
+        //Arrange
+        const teamList = [{eliminationOrder: 1}, {eliminationOrder:2}, {eliminationOrder: Number.MAX_VALUE}];
+        const league = new League(teamList);
+
+        // Act
+        const result = league.getNumberOfRounds();
+
+        // Assert
+        expect(result).not.toBe(Number.MAX_VALUE);
+    });
+
+    it("Should return the number of unique eliminationOrders", () => {
+        //Arrange
+        const teamList = [
+            {eliminationOrder: 1},
+            {eliminationOrder: 1},
+            {eliminationOrder: 3},
+        ];
+        const league = new League(teamList);
+
+        // Act
+        const result = league.getNumberOfRounds();
+
+        // Assert
+        expect(result).toBe(2);
+    });
+
+    it("Should not countin Number.MAX_VALUE as a unique number", () => {
+        //Arrange
+        const teamList = [
+            {eliminationOrder: 1},
+            {eliminationOrder: 3},
+            {eliminationOrder: Number.MAX_VALUE}
+        ];
+        const league = new League(teamList);
+
+        // Act
+        const result = league.getNumberOfRounds();
+
+        // Assert
+        expect(result).toBe(2);
+    });
+
+    it("Should not countin 0 as a unique number", () => {
+        //Arrange
+        const teamList = [
+            {eliminationOrder: 1},
+            {eliminationOrder: 3},
+            {eliminationOrder: 0}
+        ];
+        const league = new League(teamList);
+
+        // Act
+        const result = league.getNumberOfRounds();
+
+        // Assert
+        expect(result).toBe(2);
+    });
+});
+
 describe("Regression Tests Checking Scoring of Archived Leagues", () => {
 
     it("Should Score Rachel correctly for Amazing Race 35", () => {

--- a/__tests__/utils/teamListUtils.js
+++ b/__tests__/utils/teamListUtils.js
@@ -1,4 +1,4 @@
-import { shouldBeScored, getUniqueEliminationOrders, getNumberOfRounds } from "../../app/utils/teamListUtils";
+import { shouldBeScored, getUniqueEliminationOrders } from "../../app/utils/teamListUtils";
 
 describe("teamListUtils shouldBeScored", () => {
     it("should be false when there is exactly one team and we are on the first round", () => {
@@ -108,63 +108,5 @@ describe("getUniqueEliminationOrders", () => {
 
         // Assert
         expect(result).toContain(partialEliminationOrder);
-    });
-});
-
-describe("getNumberOfRounds", () => {
-    it("should not ever return Number.MAX_VALUE", () => {
-        //Arrange
-        const teamList = [{eliminationOrder: 1}, {eliminationOrder:2}, {eliminationOrder: Number.MAX_VALUE}];
-
-        // Act
-        const result = getNumberOfRounds(teamList);
-
-        // Assert
-        expect(result).not.toBe(Number.MAX_VALUE);
-    });
-
-    it("Should return the number of unique eliminationOrders", () => {
-        //Arrange
-        const teamList = [
-            {eliminationOrder: 1},
-            {eliminationOrder: 1},
-            {eliminationOrder: 3},
-        ];
-
-        // Act
-        const result = getNumberOfRounds(teamList);
-
-        // Assert
-        expect(result).toBe(2);
-    });
-
-    it("Should not countin Number.MAX_VALUE as a unique number", () => {
-        //Arrange
-        const teamList = [
-            {eliminationOrder: 1},
-            {eliminationOrder: 3},
-            {eliminationOrder: Number.MAX_VALUE}
-        ];
-
-        // Act
-        const result = getNumberOfRounds(teamList);
-
-        // Assert
-        expect(result).toBe(2);
-    });
-
-    it("Should not countin 0 as a unique number", () => {
-        //Arrange
-        const teamList = [
-            {eliminationOrder: 1},
-            {eliminationOrder: 3},
-            {eliminationOrder: 0}
-        ];
-
-        // Act
-        const result = getNumberOfRounds(teamList);
-
-        // Assert
-        expect(result).toBe(2);
     });
 });

--- a/app/generators/contestantRoundListGenerator.tsx
+++ b/app/generators/contestantRoundListGenerator.tsx
@@ -25,7 +25,8 @@ export default async function generateListOfContestantRoundLists(
         return acc;
     }, {});
 
-    const numberOfRounds = getNumberOfRounds(pageData);
+    const league = new League(pageData);
+    const numberOfRounds = league.getNumberOfRounds();
 
     const reverseTeamsList = [...pageData].reverse();
 

--- a/app/generators/contestantRoundListGenerator.tsx
+++ b/app/generators/contestantRoundListGenerator.tsx
@@ -2,7 +2,6 @@ import { getTeamList } from "../utils/wikiQuery";
 import { IContestantData } from "@/app/dataSources/dbFetch";
 import { ITableRowData } from "../dataSources/wikiFetch";
 import Team from "../models/Team";
-import { getNumberOfRounds } from "../utils/teamListUtils";
 import ContestantRoundList from "../components/contestantRoundList";
 import IRound from "../models/IRound";
 import League from "../models/League";

--- a/app/generators/contestantRoundScoreGenerator.tsx
+++ b/app/generators/contestantRoundScoreGenerator.tsx
@@ -21,9 +21,9 @@ export async function generateContestantRoundScores(
 
         return acc;
     }, {});
-    const numberOfRounds = getNumberOfRounds(pageData);
 
     const result: League = new League(pageData);
+    const numberOfRounds = result.getNumberOfRounds();
 
     listOfContestantLeagueData.map(contestant => {
 

--- a/app/generators/contestantRoundScoreGenerator.tsx
+++ b/app/generators/contestantRoundScoreGenerator.tsx
@@ -1,6 +1,5 @@
 import { ITableRowData } from "../dataSources/wikiFetch";
 import { IContestantData } from "@/app/dataSources/dbFetch";
-import { getNumberOfRounds } from "../utils/teamListUtils";
 import Team from "../models/Team";
 import League from "../models/League";
 

--- a/app/generators/contestantRoundScoreGenerator.tsx
+++ b/app/generators/contestantRoundScoreGenerator.tsx
@@ -23,7 +23,7 @@ export async function generateContestantRoundScores(
     }, {});
     const numberOfRounds = getNumberOfRounds(pageData);
 
-    const result: League = new League();
+    const result: League = new League(pageData);
 
     listOfContestantLeagueData.map(contestant => {
 

--- a/app/models/League.tsx
+++ b/app/models/League.tsx
@@ -1,6 +1,6 @@
 import IRound from "./IRound";
 import Team from "./Team";
-import { shouldBeScored } from "../utils/teamListUtils";
+import { shouldBeScored, getUniqueEliminationOrders } from "../utils/teamListUtils";
 
 export default class League {
     rounds: IRound[];
@@ -46,17 +46,9 @@ export default class League {
         }
     }
 
-    getNumberOfRounds(): number {
-        const seenOrders = new Set();
-        this.teamData.filter(
-            (t) => t.eliminationOrder !== Number.MAX_VALUE
-                && t.eliminationOrder !== 0
-        ).forEach((t) => {
-            seenOrders.add(t.eliminationOrder);
-        });
+    private getNumberOfRounds(): number {
 
-        return seenOrders.size;
-    }
+        const seenOrders = getUniqueEliminationOrders(this.teamData);
 
 
 

--- a/app/models/League.tsx
+++ b/app/models/League.tsx
@@ -6,8 +6,9 @@ export default class League {
     rounds: IRound[];
     teamData: Team[];
 
-    constructor() {
+    constructor(teamData: Team[]) {
         this.rounds = [];
+        this.teamData = teamData;
     }
 
     addContestantRoundScores(contestantTeamsList: Team[], numberOfRounds: number, contestantName: string, handicap: number): void {
@@ -48,7 +49,7 @@ export default class League {
 
     static generateContestantRoundScores(contestantTeamsList: Team[], numberOfRounds: number, contestantName: string, handicap: number): IRound[] {
 
-        const result = new League();
+        const result = new League(contestantTeamsList);
         result.addContestantRoundScores(contestantTeamsList, numberOfRounds, contestantName, handicap);
 
         return result.rounds;

--- a/app/models/League.tsx
+++ b/app/models/League.tsx
@@ -47,7 +47,7 @@ export default class League {
         }
     }
 
-    private getNumberOfRounds(): number {
+    getNumberOfRounds(): number {
         if (this.numberOfRounds !== null) {
             return this.numberOfRounds;
         }

--- a/app/models/League.tsx
+++ b/app/models/League.tsx
@@ -4,6 +4,7 @@ import { shouldBeScored } from "../utils/teamListUtils";
 
 export default class League {
     rounds: IRound[];
+    teamData: Team[];
 
     constructor() {
         this.rounds = [];

--- a/app/models/League.tsx
+++ b/app/models/League.tsx
@@ -46,6 +46,19 @@ export default class League {
         }
     }
 
+    getNumberOfRounds(): number {
+        const seenOrders = new Set();
+        this.teamData.filter(
+            (t) => t.eliminationOrder !== Number.MAX_VALUE
+                && t.eliminationOrder !== 0
+        ).forEach((t) => {
+            seenOrders.add(t.eliminationOrder);
+        });
+
+        return seenOrders.size;
+    }
+
+
 
     static generateContestantRoundScores(contestantTeamsList: Team[], numberOfRounds: number, contestantName: string, handicap: number): IRound[] {
 

--- a/app/models/League.tsx
+++ b/app/models/League.tsx
@@ -5,6 +5,7 @@ import { shouldBeScored, getUniqueEliminationOrders } from "../utils/teamListUti
 export default class League {
     rounds: IRound[];
     teamData: Team[];
+    numberOfRounds: number | null = null;
 
     constructor(teamData: Team[]) {
         this.rounds = [];
@@ -47,10 +48,16 @@ export default class League {
     }
 
     private getNumberOfRounds(): number {
+        if (this.numberOfRounds !== null) {
+            return this.numberOfRounds;
+        }
 
         const seenOrders = getUniqueEliminationOrders(this.teamData);
 
+        this.numberOfRounds = seenOrders.size;
 
+        return this.numberOfRounds;
+    }
 
     static generateContestantRoundScores(contestantTeamsList: Team[], numberOfRounds: number, contestantName: string, handicap: number): IRound[] {
 

--- a/app/utils/teamListUtils.tsx
+++ b/app/utils/teamListUtils.tsx
@@ -42,9 +42,3 @@ export function getUniqueEliminationOrders(teams: Team[]): Set<number> {
     return seenOrders;
 }
 
-export function getNumberOfRounds(teams: Team[]): number {
-    const seenOrders = getUniqueEliminationOrders(teams);
-
-    return seenOrders.size;
-}
-


### PR DESCRIPTION
### Summary/Acceptance Criteria
In the interest of moving round details into the league, which in our current estimation needs to be done in order to complete #229 in order to move the needle in that direction this PR does two things
- Update the ctor to take a list of "`Team`"s (this should be the list of definitive team data as sourced by Wikipedia)
- Move `generateNumberOfRounds` into the league and memoize it so that as we are making modifications as long as we use exactly one `League` object.

### Screenshots
N/A (internal refactor)

## Confirm
- [ ] This PR has unit tests scenarios. (No real behavior has changed just moved around)
- [x] This PR is correctly linked to the relevant issue or milestone.
- [x] This PR has been locally QA'd.
- [ ] This PR has had it's db migrations run. (N/A no new data here)

/assign me
