### PR TITLE
Feature/create generator functions to use over static ones

### DIFF
--- a/app/generators/contestantRoundListGenerator.tsx
+++ b/app/generators/contestantRoundListGenerator.tsx
@@ -30,7 +30,7 @@ export default async function generateListOfContestantRoundLists(
     const reverseTeamsList = [...pageData].reverse();
 
     const perfectScoreHandicap = 0;
-    const roundScores: IRound[] = League.generateContestantRoundScores(reverseTeamsList, numberOfRounds, "*perfect*", perfectScoreHandicap);
+    const roundScores: IRound[] = league.generateContestantRoundScores(reverseTeamsList, numberOfRounds, "*perfect*", perfectScoreHandicap);
 
     return listOfContestantLeagueData.map(contestant => {
         const currentSelectedContestantTeamsList = contestant.ranking.map((x: string) => {
@@ -39,7 +39,7 @@ export default async function generateListOfContestantRoundLists(
             return foundTeam;
         });
 
-        const contestantRoundScores: IRound[] = League.generateContestantRoundScores(currentSelectedContestantTeamsList, numberOfRounds, contestant.name, contestant.handicap);
+        const contestantRoundScores: IRound[] = league.generateContestantRoundScores(currentSelectedContestantTeamsList, numberOfRounds, contestant.name, contestant.handicap);
 
         return {
             key: contestant.name,

--- a/app/generators/contestantRoundListGenerator.tsx
+++ b/app/generators/contestantRoundListGenerator.tsx
@@ -25,12 +25,11 @@ export default async function generateListOfContestantRoundLists(
     }, {});
 
     const league = new League(pageData);
-    const numberOfRounds = league.getNumberOfRounds();
 
     const reverseTeamsList = [...pageData].reverse();
 
     const perfectScoreHandicap = 0;
-    const roundScores: IRound[] = league.generateContestantRoundScores(reverseTeamsList, numberOfRounds, "*perfect*", perfectScoreHandicap);
+    const roundScores: IRound[] = league.generateContestantRoundScores(reverseTeamsList, "*perfect*", perfectScoreHandicap);
 
     return listOfContestantLeagueData.map(contestant => {
         const currentSelectedContestantTeamsList = contestant.ranking.map((x: string) => {
@@ -39,7 +38,7 @@ export default async function generateListOfContestantRoundLists(
             return foundTeam;
         });
 
-        const contestantRoundScores: IRound[] = league.generateContestantRoundScores(currentSelectedContestantTeamsList, numberOfRounds, contestant.name, contestant.handicap);
+        const contestantRoundScores: IRound[] = league.generateContestantRoundScores(currentSelectedContestantTeamsList, contestant.name, contestant.handicap);
 
         return {
             key: contestant.name,

--- a/app/generators/contestantRoundScoreGenerator.tsx
+++ b/app/generators/contestantRoundScoreGenerator.tsx
@@ -22,7 +22,6 @@ export async function generateContestantRoundScores(
     }, {});
 
     const result: League = new League(pageData);
-    const numberOfRounds = result.getNumberOfRounds();
 
     listOfContestantLeagueData.map(contestant => {
 
@@ -31,7 +30,7 @@ export async function generateContestantRoundScores(
             return foundTeam;
         });
 
-        result.addContestantRoundScores(currentSelectedContestantTeamsList, numberOfRounds, contestant.name, contestant.handicap);
+        result.addContestantRoundScores(currentSelectedContestantTeamsList, contestant.name, contestant.handicap);
 
     });
 

--- a/app/models/League.tsx
+++ b/app/models/League.tsx
@@ -47,10 +47,15 @@ export default class League {
 
     addContestantRoundScores(contestantTeamsList: Team[], contestantName: string, handicap: number): void {
 
-        this.calculateContestantRoundScores(contestantTeamsList, contestantName, handicap, (roundNumber, elimOrder, countOfTeamsElimedThisFar, contestantLeagueData) => {
-            const currentRound = this.rounds[roundNumber]
-            currentRound.contestantRoundData.push(contestantLeagueData);
-        });
+        this.calculateContestantRoundScores(
+            contestantTeamsList,
+            contestantName,
+            handicap,
+            (roundNumber, elimOrder, countOfTeamsElimedThisFar, contestantLeagueData) => {
+                const currentRound = this.rounds[roundNumber]
+                currentRound.contestantRoundData.push(contestantLeagueData);
+            }
+        );
     }
 
     private calculateContestantRoundScores(
@@ -94,14 +99,19 @@ export default class League {
         }
 
         const result: IRound[] = [];
-        this.calculateContestantRoundScores(contestantTeamsList, contestantName, handicap, (roundNumber, elimOrder, teamsElimedSoFar, contestantLeagueData) => {
-            result.push({
-                round: roundNumber,
-                eliminationOrder: elimOrder,
-                teamsEliminatedSoFar: teamsElimedSoFar,
-                contestantRoundData: [contestantLeagueData]
-            });
-        });
+        this.calculateContestantRoundScores(
+            contestantTeamsList,
+            contestantName,
+            handicap,
+            (roundNumber, elimOrder, teamsElimedSoFar, contestantLeagueData) => {
+                result.push({
+                    round: roundNumber,
+                    eliminationOrder: elimOrder,
+                    teamsEliminatedSoFar: teamsElimedSoFar,
+                    contestantRoundData: [contestantLeagueData]
+                });
+            }
+        );
 
         return result;
     }

--- a/app/models/League.tsx
+++ b/app/models/League.tsx
@@ -89,7 +89,7 @@ export default class League {
 
     generateContestantRoundScores(contestantTeamsList: Team[], contestantName: string, handicap: number): IRound[] {
 
-        if (numberOfRounds > contestantTeamsList.length) {
+        if (this.numberOfRounds > contestantTeamsList.length) {
             throw new Error("Asking for more rounds that the number of teams in the list");
         }
 

--- a/app/models/League.tsx
+++ b/app/models/League.tsx
@@ -47,7 +47,7 @@ export default class League {
 
     addContestantRoundScores(contestantTeamsList: Team[], numberOfRounds: number, contestantName: string, handicap: number): void {
 
-        this.calculateContestantRoundScores(contestantTeamsList, numberOfRounds, contestantName, handicap, (roundNumber, elimOrder, countOfTeamsElimedThisFar, contestantLeagueData) => {
+        this.calculateContestantRoundScores(contestantTeamsList, contestantName, handicap, (roundNumber, elimOrder, countOfTeamsElimedThisFar, contestantLeagueData) => {
             const currentRound = this.rounds[roundNumber]
             currentRound.contestantRoundData.push(contestantLeagueData);
         });
@@ -55,13 +55,13 @@ export default class League {
 
     private calculateContestantRoundScores(
         contestantTeamsList: Team[],
-        numberOfRounds: number,
         contestantName: string,
         handicap: number,
         addToRoundList: (_n: number, _eo: number, _cot: number, _crd: IContestantRoundData) => void
     ): void {
 
         let grandTotal = handicap === undefined ? 0 : handicap;
+        const numberOfRounds = this.getNumberOfRounds();
         for(let i = 0; i < numberOfRounds; i++) {
             const currentRound = this.rounds[i];
             const elimOrder = currentRound.eliminationOrder;
@@ -94,7 +94,7 @@ export default class League {
         }
 
         const result: IRound[] = [];
-        this.calculateContestantRoundScores(contestantTeamsList, numberOfRounds, contestantName, handicap, (roundNumber, elimOrder, teamsElimedSoFar, contestantLeagueData) => {
+        this.calculateContestantRoundScores(contestantTeamsList, contestantName, handicap, (roundNumber, elimOrder, teamsElimedSoFar, contestantLeagueData) => {
             result.push({
                 round: roundNumber,
                 eliminationOrder: elimOrder,

--- a/app/models/League.tsx
+++ b/app/models/League.tsx
@@ -47,27 +47,10 @@ export default class League {
 
     addContestantRoundScores(contestantTeamsList: Team[], numberOfRounds: number, contestantName: string, handicap: number): void {
 
-        let grandTotal = handicap === undefined ? 0 : handicap;
-        for(let i = 0; i < numberOfRounds; i++) {
-            const currentRound = this.rounds[i];
-            const elimOrder = currentRound.eliminationOrder;
-            const countOfTeamsElimedThisFar = currentRound.teamsEliminatedSoFar;
-            const roundScore = contestantTeamsList.reduce(
-                (acc: number, x: Team) => {
-                    const teamShouldBeScored = shouldBeScored(contestantTeamsList, x, elimOrder, countOfTeamsElimedThisFar);
-    
-                    return teamShouldBeScored ? acc + 10 : acc;
-                }, 0);
-
-            grandTotal += roundScore;
-
-            currentRound.contestantRoundData.push({
-                name: contestantName,
-                roundScore: roundScore,
-                totalScore: grandTotal
-            });
-
-        }
+        this.calculateContestantRoundScores(contestantTeamsList, numberOfRounds, contestantName, handicap, (roundNumber, elimOrder, countOfTeamsElimedThisFar, contestantLeagueData) => {
+            const currentRound = this.rounds[roundNumber]
+            currentRound.contestantRoundData.push(contestantLeagueData);
+        });
     }
 
     private calculateContestantRoundScores(
@@ -111,10 +94,10 @@ export default class League {
         }
 
         const result: IRound[] = [];
-        this.calculateContestantRoundScores(contestantTeamsList, numberOfRounds, contestantName, handicap, (roundNumber, eliminationOrder, teamsElimedSoFar, contestantLeagueData) => {
+        this.calculateContestantRoundScores(contestantTeamsList, numberOfRounds, contestantName, handicap, (roundNumber, elimOrder, teamsElimedSoFar, contestantLeagueData) => {
             result.push({
                 round: roundNumber,
-                eliminationOrder: eliminationOrder,
+                eliminationOrder: elimOrder,
                 teamsEliminatedSoFar: teamsElimedSoFar,
                 contestantRoundData: [contestantLeagueData]
             });

--- a/app/models/League.tsx
+++ b/app/models/League.tsx
@@ -45,7 +45,7 @@ export default class League {
         }
     }
 
-    addContestantRoundScores(contestantTeamsList: Team[], numberOfRounds: number, contestantName: string, handicap: number): void {
+    addContestantRoundScores(contestantTeamsList: Team[], contestantName: string, handicap: number): void {
 
         this.calculateContestantRoundScores(contestantTeamsList, contestantName, handicap, (roundNumber, elimOrder, countOfTeamsElimedThisFar, contestantLeagueData) => {
             const currentRound = this.rounds[roundNumber]

--- a/app/models/League.tsx
+++ b/app/models/League.tsx
@@ -110,10 +110,18 @@ export default class League {
             throw new Error("Asking for more rounds that the number of teams in the list");
         }
 
-        const result = new League(contestantTeamsList);
-        result.addContestantRoundScores(contestantTeamsList, numberOfRounds, contestantName, handicap);
+        const league = new League(contestantTeamsList);
+        const result: IRound[] = [];
+        league.calculateContestantRoundScores(contestantTeamsList, numberOfRounds, contestantName, handicap, (roundNumber, eliminationOrder, teamsElimedSoFar, contestantLeagueData) => {
+            result.push({
+                round: roundNumber,
+                eliminationOrder: eliminationOrder,
+                teamsEliminatedSoFar: teamsElimedSoFar,
+                contestantRoundData: [contestantLeagueData]
+            });
+        });
 
-        return result.rounds;
+        return result;
     }
 } 
 

--- a/app/models/League.tsx
+++ b/app/models/League.tsx
@@ -1,4 +1,5 @@
 import IRound from "./IRound";
+import IContestantRoundData from "./IContestantRoundData";
 import Team from "./Team";
 import { shouldBeScored, getNumberOfTeamsToEliminate, getRoundEliminationOrderMapping, getUniqueEliminationOrders } from "../utils/teamListUtils";
 
@@ -66,6 +67,33 @@ export default class League {
                 totalScore: grandTotal
             });
 
+        }
+    }
+
+    private calculateContestantRoundScores(
+        contestantTeamsList: Team[],
+        numberOfRounds: number,
+        contestantName: string,
+        handicap: number,
+        addToRoundList: (_n: number, _crd: IContestantRoundData) => void
+    ): void {
+
+        let grandTotal = handicap === undefined ? 0 : handicap;
+        for(let i = 0; i < numberOfRounds; i++) {
+            const roundScore = contestantTeamsList.reduce(
+                (acc: number, x: Team) => {
+                    const teamShouldBeScored = shouldBeScored(contestantTeamsList, x, i);
+    
+                    return teamShouldBeScored ? acc + 10 : acc;
+                }, 0);
+
+            grandTotal += roundScore;
+
+            addToRoundList(i, {
+                name: contestantName,
+                roundScore: roundScore,
+                totalScore: grandTotal
+            });
         }
     }
 

--- a/app/models/League.tsx
+++ b/app/models/League.tsx
@@ -104,15 +104,14 @@ export default class League {
         return this.numberOfRounds;
     }
 
-    static generateContestantRoundScores(contestantTeamsList: Team[], numberOfRounds: number, contestantName: string, handicap: number): IRound[] {
+    generateContestantRoundScores(contestantTeamsList: Team[], numberOfRounds: number, contestantName: string, handicap: number): IRound[] {
 
         if (numberOfRounds > contestantTeamsList.length) {
             throw new Error("Asking for more rounds that the number of teams in the list");
         }
 
-        const league = new League(contestantTeamsList);
         const result: IRound[] = [];
-        league.calculateContestantRoundScores(contestantTeamsList, numberOfRounds, contestantName, handicap, (roundNumber, eliminationOrder, teamsElimedSoFar, contestantLeagueData) => {
+        this.calculateContestantRoundScores(contestantTeamsList, numberOfRounds, contestantName, handicap, (roundNumber, eliminationOrder, teamsElimedSoFar, contestantLeagueData) => {
             result.push({
                 round: roundNumber,
                 eliminationOrder: eliminationOrder,

--- a/app/models/League.tsx
+++ b/app/models/League.tsx
@@ -87,7 +87,7 @@ export default class League {
         return this.numberOfRounds;
     }
 
-    generateContestantRoundScores(contestantTeamsList: Team[], numberOfRounds: number, contestantName: string, handicap: number): IRound[] {
+    generateContestantRoundScores(contestantTeamsList: Team[], contestantName: string, handicap: number): IRound[] {
 
         if (numberOfRounds > contestantTeamsList.length) {
             throw new Error("Asking for more rounds that the number of teams in the list");

--- a/app/models/League.tsx
+++ b/app/models/League.tsx
@@ -75,21 +75,24 @@ export default class League {
         numberOfRounds: number,
         contestantName: string,
         handicap: number,
-        addToRoundList: (_n: number, _crd: IContestantRoundData) => void
+        addToRoundList: (_n: number, _eo: number, _cot: number, _crd: IContestantRoundData) => void
     ): void {
 
         let grandTotal = handicap === undefined ? 0 : handicap;
         for(let i = 0; i < numberOfRounds; i++) {
+            const currentRound = this.rounds[i];
+            const elimOrder = currentRound.eliminationOrder;
+            const countOfTeamsElimedThisFar = currentRound.teamsEliminatedSoFar;
             const roundScore = contestantTeamsList.reduce(
                 (acc: number, x: Team) => {
-                    const teamShouldBeScored = shouldBeScored(contestantTeamsList, x, i);
-    
+                    const teamShouldBeScored = shouldBeScored(contestantTeamsList, x, elimOrder, countOfTeamsElimedThisFar);
+
                     return teamShouldBeScored ? acc + 10 : acc;
                 }, 0);
 
             grandTotal += roundScore;
 
-            addToRoundList(i, {
+            addToRoundList(i, elimOrder, countOfTeamsElimedThisFar, {
                 name: contestantName,
                 roundScore: roundScore,
                 totalScore: grandTotal


### PR DESCRIPTION
### Summary/Acceptance Criteria
Here is another step in the direction that will help us address #229. This step sets us up to not have to call getNumberOfRounds more than once per league generated, even including for the scoring page where we used to make a static call we will now make a call on the instance which instead of adding to the leagues list of `IRound`s it will instead just return a new instance of `IRound[]` but still use the same value for numberOfRounds achieving the exact same buildtime characteristic as before this change, while also making sure that `getNumberOfRounds` can basically be treated as private. 

### Changes to look for
- Made `generateContestantRoundScores` an instance method (in order to leverage a memoized `numberOfRouds`)
- Memoized the `numberOfRounds` (meaning we no longer need to precalculate it)
- Remove all passing around and precalculating of `numberOfRounds`

### Screenshots
N/A (this is a _very_ superficial refactor that may or may not be valuable)

## Confirm
- [ ] This PR has unit tests scenarios. _(All the necessary tests already exist IMHO)_
- [ ] This PR is correctly linked to the relevant issue or milestone. _(Not sure if this goes in a milestone... not sure if this is a change that we want at all)_
- [x] This PR has been locally QA'd.
- [ ] This PR has had it's db migrations run. _(n/a there is no new data with this PR)_

/assign me
