### PR TITLE
Fixed Navigation errors

### DIFF
--- a/app/components/navigation/navigation-item.tsx
+++ b/app/components/navigation/navigation-item.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import INavigationItem from "@/app/models/INavigationItem";
-export default function NavigationItem({ inputAttr, labelAttr, listAttr, children, hasSubpages }: INavigationItem) {
+export default function NavigationItem({ inputAttr, labelAttr, listAttr, childElements, hasSubpages }: INavigationItem) {
     const [isHidden, setIsHidden] = useState(true);
     return (<>
         <input 
@@ -15,6 +15,6 @@ export default function NavigationItem({ inputAttr, labelAttr, listAttr, childre
             aria-controls={labelAttr.aria.controls}
             data-testid={labelAttr.testId}
             className={labelAttr.classes }>{labelAttr.content}</label>
-        {hasSubpages && <ul className={listAttr.classes}  id={listAttr.id} data-testid={listAttr.testId} aria-hidden={isHidden} hidden={isHidden}>{children}</ul>}
+        {hasSubpages && <ul className={listAttr.classes}  id={listAttr.id} data-testid={listAttr.testId} aria-hidden={isHidden} hidden={isHidden}>{childElements}</ul>}
     </>);
 }

--- a/app/components/navigation/navigation.tsx
+++ b/app/components/navigation/navigation.tsx
@@ -27,9 +27,9 @@ export default function Navigation({ pages }: {
         classes: ""
     };
     return (<nav id={styles["navigation"]} data-testid="navigation">
-        <NavigationItem inputAttr={rootNavInputAttr} labelAttr={rootNavLabelAttr} listAttr={rootNavListAttr} hasSubpages={ pages.length > 0} children={pages.map((page: IPage) => {
+        <NavigationItem inputAttr={rootNavInputAttr} labelAttr={rootNavLabelAttr} listAttr={rootNavListAttr} hasSubpages={ pages.length > 0} childElements={pages.map((page: IPage) => {
             const keyName = page.name.toLowerCase().replaceAll(" ", "-");
-            const hasSubpages = page.hasOwnProperty("subpages") && page.subpages.length > 0;
+            const hasSubpages = page?.subpages && page.subpages.length > 0;
             const subpageInputAttr = {
                 id: `subpage-${keyName}-input`,
                 classes: styles["nav-subpages-toggle"],
@@ -49,7 +49,7 @@ export default function Navigation({ pages }: {
                 classes: styles["nav-subpages-list"]
             };
             return (<li key={`nav-toplevellink-${keyName}`} className={styles["nav-toplevel-page"]}>
-                <NavigationItem hasSubpages={hasSubpages }  inputAttr={subpageInputAttr } labelAttr={subpageLabelAttr } listAttr={ subpageListAttr} children={page.subpages.map((subpage: ISubpage) => {
+                <NavigationItem hasSubpages={hasSubpages }  inputAttr={subpageInputAttr } labelAttr={subpageLabelAttr } listAttr={ subpageListAttr} childElements={page.subpages.map((subpage: ISubpage) => {
                     const subpageKeyName = subpage.name.toLowerCase().replaceAll(" ", "-");
                     return <li key={`nav-toplevellink-${keyName}-sublink-${subpageKeyName}`}>
                         <Link href={subpage.path} className={styles["sub-level-link"]}>{subpage.name}</Link>

--- a/app/models/INavigationItem.tsx
+++ b/app/models/INavigationItem.tsx
@@ -27,6 +27,6 @@ export default interface INavigationItem{
     inputAttr: IInputAttribute
     labelAttr: ILabelAttribute
     listAttr: IListAttribute
-    children: ReactNode
+    childElements: ReactNode
     hasSubpages: boolean
 };

--- a/app/utils/leagueUtils.tsx
+++ b/app/utils/leagueUtils.tsx
@@ -5,12 +5,12 @@ export interface SeasonNameRepo {
 }
 
 export function transformFilenameToSeasonNameRepo(fileName: string): SeasonNameRepo {
-    const showAndSeason = fileName.split('_');
+    const showAndSeason = fileName.split("_");
     const showNameArray = showAndSeason[0].split(/(?<![A-Z])(?=[A-Z])/);
-    const showNameFormatted = showNameArray.join('-').toLowerCase();
-    const showSeason = showAndSeason[1].replace('.js', '');
+    const showNameFormatted = showNameArray.join("-").toLowerCase();
+    const showSeason = showAndSeason[1].replace(".js", "");
     const showNameAndSeason = `${showNameFormatted}-${showSeason}`;
-    const friendlyName = `${showNameArray.join(' ')} ${showSeason}`;
+    const friendlyName = `${showNameArray.join(" ")} ${showSeason}`;
 
     return { urlSlug: showNameAndSeason, friendlyName: friendlyName }
 }


### PR DESCRIPTION
### Summary/Acceptance Criteria
- Changed NavigationItem prop. Children is a reserved keyword
- Replaced hasOwnProperty error

After merging this, I recommend removing the .next and node_modules folders and running `npm install`. ESLint needs to reinstall based on the config to ignore the proper paths.

## Confirm
- [x] This PR has unit tests scenarios. (N/A)
- [x] This PR is correctly linked to the relevant issue or milestone.
- [x] This PR has been locally QA'd. (N/A)
- [x] This PR has had it's db migrations run. (not necessary)

/assign me
