### PR TITLE
Feature/extract round elim mapping

### DIFF
--- a/__tests__/models/League.js
+++ b/__tests__/models/League.js
@@ -131,7 +131,7 @@ describe("addContestantRoundScores", () => {
         const rounds = 1;
         const expectedContestantName1 = "contestant1";
         const expectedContestantName2 = "contestant2";
-        const sut = new League();
+        const sut = new League(teamList);
 
         // Act
         sut.addContestantRoundScores(teamList, rounds, expectedContestantName1);
@@ -154,7 +154,7 @@ describe("addContestantRoundScores", () => {
         const teamList = [exampleTeam, exampleTeam2, exampleTeam3];
         const rounds = 1;
         const expectedContestantName1 = "contestant1";
-        const sut = new League();
+        const sut = new League(teamList);
 
         // Act
         sut.addContestantRoundScores(teamList, rounds, expectedContestantName1);
@@ -176,7 +176,7 @@ describe("addContestantRoundScores", () => {
         const rounds = 1;
         const expectedContestantName1 = "contestant1";
         const expectedHandicap = -10;
-        const sut = new League();
+        const sut = new League(teamList);
 
         // Act
         sut.addContestantRoundScores(teamList, rounds, expectedContestantName1, expectedHandicap);

--- a/__tests__/utils/teamListUtils.js
+++ b/__tests__/utils/teamListUtils.js
@@ -71,7 +71,7 @@ describe("teamListUtils shouldBeScored", () => {
         const teamList = [aTeam, {}];
 
         // Act
-        shouldBeScored(teamList, aTeam, 0);
+        shouldBeScored(teamList, aTeam, 0, 1); // the last argument is now just the current elimOrder
 
         // Assert
         expect(aTeam.isInPlay).toHaveBeenCalledWith(1);
@@ -86,7 +86,7 @@ describe("teamListUtils shouldBeScored", () => {
         const teamList = [aTeam, { eliminationOrder: 1 }, { eliminationOrder: 1 }];
 
         // Act
-        shouldBeScored(teamList, aTeam, 1); // this is round 2, by 0 indexing
+        shouldBeScored(teamList, aTeam, 1, 3); // the last argument is now just the current elimOrder
 
         // Assert
         expect(aTeam.isInPlay).toHaveBeenCalledWith(3);

--- a/app/components/contestantRoundList.tsx
+++ b/app/components/contestantRoundList.tsx
@@ -36,6 +36,8 @@ export default function ContestantRoundList({
                 const contestantRoundScore = filteredContestantRound.roundScore;
                 const contestantGrandTotal = filteredContestantRound.totalScore;
 
+                const elimOrder = roundElimMapping[roundNumber];
+
                 return <Round
                     key={"round"+roundNumber}
                     roundNumber={roundNumber}

--- a/app/components/contestantRoundList.tsx
+++ b/app/components/contestantRoundList.tsx
@@ -41,6 +41,7 @@ export default function ContestantRoundList({
                 return <Round
                     key={"round"+roundNumber}
                     roundNumber={roundNumber}
+                    eliminationOrder={elimOrder}
                     perfectTeamList={perfectTeamList}
                     contestantTeamList={contestantTeamList}
                     perfectWeekScore={perfectScore}

--- a/app/components/contestantRoundList.tsx
+++ b/app/components/contestantRoundList.tsx
@@ -1,3 +1,4 @@
+import { getRoundEliminationOrderMapping } from "@/app/utils/teamListUtils"
 import Round from "./round";
 import Team from "../models/Team";
 import IRound from "../models/IRound";

--- a/app/components/contestantRoundList.tsx
+++ b/app/components/contestantRoundList.tsx
@@ -18,6 +18,8 @@ export default function ContestantRoundList({
         contestantName: string
     }) {
 
+    const roundElimMapping = getRoundEliminationOrderMapping(perfectTeamList);
+
     return (<>
         <div className="text-center">
             {perfectRoundScores.map((round: IRound, roundNumber: number) => {

--- a/app/components/round.tsx
+++ b/app/components/round.tsx
@@ -4,6 +4,7 @@ import Team from "../models/Team";
 
 export default function Round({
     roundNumber,
+    eliminationOrder,
     perfectTeamList,
     contestantTeamList,
     perfectWeekScore,
@@ -12,6 +13,7 @@ export default function Round({
     contestantGrandTotal
 }: {
         roundNumber: number
+        eliminationOrder: number
         perfectTeamList: Team[]
         contestantTeamList: Team[]
         perfectWeekScore: number

--- a/app/components/round.tsx
+++ b/app/components/round.tsx
@@ -29,12 +29,14 @@ export default function Round({
                 <TeamList
                     teamList={perfectTeamList}
                     roundNumber={roundNumber}
+                    eliminationOrder={eliminationOrder}
                 />
             </div>
             <div className="basis-1/2">
                 <TeamList
                     teamList={contestantTeamList}
                     roundNumber={roundNumber}
+                    eliminationOrder={eliminationOrder}
                 />
             </div>
         </div>

--- a/app/components/round.tsx
+++ b/app/components/round.tsx
@@ -26,10 +26,16 @@ export default function Round({
         <h2 key={"weekHeader"+roundNumber}className="text-xl">Week {roundNumber+1}</h2>
         <div className="text-center flex">
             <div className="basis-1/2">
-                <TeamList teamList={perfectTeamList} roundNumber={roundNumber} />
+                <TeamList
+                    teamList={perfectTeamList}
+                    roundNumber={roundNumber}
+                />
             </div>
             <div className="basis-1/2">
-                <TeamList teamList={contestantTeamList} roundNumber={roundNumber} />
+                <TeamList
+                    teamList={contestantTeamList}
+                    roundNumber={roundNumber}
+                />
             </div>
         </div>
         <br/>

--- a/app/components/teamList.tsx
+++ b/app/components/teamList.tsx
@@ -15,7 +15,7 @@ export default function TeamList({
         {teamList.map(t => {
             return (<Fragment key={"teamStanding"+t.teamName+roundNumber}>
                 <p key={t.teamName+roundNumber}>
-                    {shouldBeScored(teamList, t, roundNumber) ? t.friendlyName() : <s>{t.friendlyName()}</s> }
+                    {shouldBeScored(teamList, t, roundNumber, eliminationOrder) ? t.friendlyName() : <s>{t.friendlyName()}</s> }
                 </p>
             </Fragment>);
         })}

--- a/app/components/teamList.tsx
+++ b/app/components/teamList.tsx
@@ -4,10 +4,12 @@ import { shouldBeScored } from "../utils/teamListUtils";
 
 export default function TeamList({
     teamList,
-    roundNumber
+    roundNumber,
+    eliminationOrder
 }: {
     teamList: Team[],
     roundNumber: number
+    eliminationOrder: number
 }) {
     return <div>
         {teamList.map(t => {

--- a/app/components/teamList.tsx
+++ b/app/components/teamList.tsx
@@ -2,7 +2,13 @@ import { Fragment } from "react";
 import Team from "../models/Team";
 import { shouldBeScored } from "../utils/teamListUtils";
 
-export default function TeamList({ teamList, roundNumber }: { teamList: Team[], roundNumber: number }) {
+export default function TeamList({
+    teamList,
+    roundNumber
+}: {
+    teamList: Team[],
+    roundNumber: number
+}) {
     return <div>
         {teamList.map(t => {
             return (<Fragment key={"teamStanding"+t.teamName+roundNumber}>

--- a/app/models/League.tsx
+++ b/app/models/League.tsx
@@ -15,6 +15,7 @@ export default class League {
     addContestantRoundScores(contestantTeamsList: Team[], numberOfRounds: number, contestantName: string, handicap: number): void {
 
         let grandTotal = handicap === undefined ? 0 : handicap;
+        const roundElimMapping = getRoundEliminationOrderMapping(this.teamData);
         for(let i = 0; i < numberOfRounds; i++) {
             const roundScore = contestantTeamsList.reduce(
                 (acc: number, x: Team) => {

--- a/app/models/League.tsx
+++ b/app/models/League.tsx
@@ -19,6 +19,8 @@ export default class League {
         for(let i = 0; i < numberOfRounds; i++) {
             const roundScore = contestantTeamsList.reduce(
                 (acc: number, x: Team) => {
+                    const elimOrder = roundElimMapping[i];
+
                     const teamShouldBeScored = shouldBeScored(contestantTeamsList, x, i);
     
                     return teamShouldBeScored ? acc + 10 : acc;

--- a/app/models/League.tsx
+++ b/app/models/League.tsx
@@ -21,7 +21,7 @@ export default class League {
                 (acc: number, x: Team) => {
                     const elimOrder = roundElimMapping[i];
 
-                    const teamShouldBeScored = shouldBeScored(contestantTeamsList, x, i);
+                    const teamShouldBeScored = shouldBeScored(contestantTeamsList, x, i, elimOrder);
     
                     return teamShouldBeScored ? acc + 10 : acc;
                 }, 0);

--- a/app/models/League.tsx
+++ b/app/models/League.tsx
@@ -1,6 +1,6 @@
 import IRound from "./IRound";
 import Team from "./Team";
-import { shouldBeScored, getUniqueEliminationOrders } from "../utils/teamListUtils";
+import { shouldBeScored, getRoundEliminationOrderMapping, getUniqueEliminationOrders } from "../utils/teamListUtils";
 
 export default class League {
     rounds: IRound[];

--- a/app/utils/teamListUtils.tsx
+++ b/app/utils/teamListUtils.tsx
@@ -4,7 +4,7 @@ interface RoundEliminationOrderMapping {
     [Key: string]: number;
 }
 
-export function shouldBeScored(teamList: Team[], team: Team, roundNumber: number, eliminationOrder): boolean {
+export function shouldBeScored(teamList: Team[], team: Team, roundNumber: number, eliminationOrder: number): boolean {
 
     const teamPosition = teamList.length - teamList.indexOf(team);
 

--- a/app/utils/teamListUtils.tsx
+++ b/app/utils/teamListUtils.tsx
@@ -4,7 +4,7 @@ interface RoundEliminationOrderMapping {
     [Key: string]: number;
 }
 
-export function shouldBeScored(teamList: Team[], team: Team, roundNumber: number): boolean {
+export function shouldBeScored(teamList: Team[], team: Team, roundNumber: number, eliminationOrder): boolean {
 
     const teamPosition = teamList.length - teamList.indexOf(team);
 

--- a/app/utils/teamListUtils.tsx
+++ b/app/utils/teamListUtils.tsx
@@ -11,11 +11,7 @@ export function shouldBeScored(teamList: Team[], team: Team, roundNumber: number
     const currentWeek = roundNumber+1;
     const listHasTeamBeingEliminated = teamPosition <= currentWeek;
 
-    const roundElimMapping = getRoundEliminationOrderMapping(teamList);
-
-    const elimOrder = roundElimMapping[roundNumber];
-
-    return team.isInPlay(elimOrder) && !listHasTeamBeingEliminated;
+    return team.isInPlay(eliminationOrder) && !listHasTeamBeingEliminated;
 }
 
 export function getRoundEliminationOrderMapping(teamList: Team[]): RoundEliminationOrderMapping {

--- a/app/utils/teamListUtils.tsx
+++ b/app/utils/teamListUtils.tsx
@@ -18,7 +18,7 @@ export function shouldBeScored(teamList: Team[], team: Team, roundNumber: number
     return team.isInPlay(elimOrder) && !listHasTeamBeingEliminated;
 }
 
-function getRoundEliminationOrderMapping(teamList: Team[]): RoundEliminationOrderMapping {
+export function getRoundEliminationOrderMapping(teamList: Team[]): RoundEliminationOrderMapping {
     const setOfEliminationOrders = getUniqueEliminationOrders(teamList);
     const listOfEliminationOrders = Array.from(setOfEliminationOrders)
     listOfEliminationOrders.sort((x, y) => Number(x) - Number(y));


### PR DESCRIPTION
### Summary/Acceptance Criteria
In order to front-load and cache about as much as is reasonable given our current designs we would like to extract the calling of generating the rountToEliminationOrder mapping to be done at a higher level. This goes a good way to getting us to that place.

This sets us up better to solve #229 

### Screenshots
anecdotally this goes from having that generator called ~2.8k times per league to ~30 times

## Confirm
- [ ] This PR has unit tests scenarios. (No new tests, but based on personal review I feel like we actually have everything covered with the existing tests)
- [x] This PR is correctly linked to the relevant issue or milestone.
- [x] This PR has been locally QA'd.
- [ ] This PR has had it's db migrations run. (N/A no new data in this)

/assign me
