### PR TITLE
267 stop constructing a brand new league to generate a single contestantsroundscores

### DIFF
--- a/__tests__/models/League.js
+++ b/__tests__/models/League.js
@@ -263,9 +263,10 @@ describe("Regression Tests Checking Scoring of Archived Leagues", () => {
 
         const numberOfRounds = 12;
         const handicap = 0;
+        const sut = new League(rachelsParsedAndEmbelishedTeamList);
 
         // Act
-        const rachelsRoundScores = League.generateContestantRoundScores(rachelsParsedAndEmbelishedTeamList, numberOfRounds, "testingRach", handicap);
+        const rachelsRoundScores = sut.generateContestantRoundScores(rachelsParsedAndEmbelishedTeamList, numberOfRounds, "testingRach", handicap);
 
         // Assert
         expect(rachelsRoundScores.length).toBe(numberOfRounds);
@@ -345,9 +346,10 @@ describe("Regression Tests Checking Scoring of Archived Leagues", () => {
 
         const numberOfRounds = 12;
         const handicap = 0;
+        const sut = new League(anitasParsedAndEmbelishedTeamList);
 
         // Act
-        const anitasRoundScores = League.generateContestantRoundScores(anitasParsedAndEmbelishedTeamList, numberOfRounds, "testingAnita", handicap);
+        const anitasRoundScores = sut.generateContestantRoundScores(anitasParsedAndEmbelishedTeamList, numberOfRounds, "testingAnita", handicap);
 
         // Assert
         expect(anitasRoundScores.length).toBe(numberOfRounds);
@@ -428,9 +430,10 @@ describe("Regression Tests Checking Scoring of Archived Leagues", () => {
 
         const numberOfRounds = 15;
         const handicap = 0;
+        const sut = new League(seansParsedAndEmbelishedTeamList);
 
         // Act
-        const seansRoundScores = League.generateContestantRoundScores(seansParsedAndEmbelishedTeamList, numberOfRounds, "testingSean", handicap);
+        const seansRoundScores = sut.generateContestantRoundScores(seansParsedAndEmbelishedTeamList, numberOfRounds, "testingSean", handicap);
 
         // Assert
         expect(seansRoundScores.length).toBe(numberOfRounds);

--- a/__tests__/models/League.js
+++ b/__tests__/models/League.js
@@ -6,9 +6,10 @@ describe("generateContestantRoundScores", () => {
         // Arrange
         const teamList  = [];
         const rounds = 0;
+        const sut = new League(teamList);
 
         // Act
-        const result = League.generateContestantRoundScores(teamList, rounds, "");
+        const result = sut.generateContestantRoundScores(teamList, rounds, "");
 
         // Assert
         expect(result).not.toBeNull();
@@ -19,9 +20,10 @@ describe("generateContestantRoundScores", () => {
         // Arrange
         const teamList  = [];
         const rounds = 1;
+        const sut = new League(teamList);
 
         // Act
-        const resultFunc = () => League.generateContestantRoundScores(teamList, rounds, "");
+        const resultFunc = () => sut.generateContestantRoundScores(teamList, rounds, "");
 
         // Assert
         expect(resultFunc).toThrow("more rounds");
@@ -31,9 +33,10 @@ describe("generateContestantRoundScores", () => {
         // Arrange
         const teamList = [new Team({teamName: "name1_1 & name1_2"})];
         const rounds = 1;
+        const sut = new League(teamList)
 
         // Act
-        const result = League.generateContestantRoundScores(teamList, rounds, "");
+        const result = sut.generateContestantRoundScores(teamList, rounds, "");
 
         // Assert
         expect(result).not.toBeNull();
@@ -49,9 +52,10 @@ describe("generateContestantRoundScores", () => {
 
         const teamList = [exampleTeam, exampleTeam2];
         const rounds = 1;
+        const sut = new League(teamList);
 
         // Act
-        const result = League.generateContestantRoundScores(teamList, rounds, "");
+        const result = sut.generateContestantRoundScores(teamList, rounds, "");
 
         // Assert
         expect(result).not.toBeNull();
@@ -71,9 +75,10 @@ describe("generateContestantRoundScores", () => {
 
         const teamList = [exampleTeam, exampleTeam2, exampleTeam3];
         const rounds = 1;
+        const sut = new League(teamList);
 
         // Act
-        const result = League.generateContestantRoundScores(teamList, rounds, "");
+        const result = sut.generateContestantRoundScores(teamList, rounds, "");
 
         // Assert
         expect(result).not.toBeNull();
@@ -93,9 +98,10 @@ describe("generateContestantRoundScores", () => {
 
         const teamList = [exampleTeam, exampleTeam2, exampleTeam3];
         const rounds = 2;
+        const sut = new League(teamList);
 
         // Act
-        const result = League.generateContestantRoundScores(teamList, rounds, "");
+        const result = sut.generateContestantRoundScores(teamList, rounds, "");
 
         // Assert
         expect(result).not.toBeNull();

--- a/__tests__/models/League.js
+++ b/__tests__/models/League.js
@@ -24,7 +24,7 @@ describe("generateContestantRoundScores", () => {
         const resultFunc = () => League.generateContestantRoundScores(teamList, rounds, "");
 
         // Assert
-        expect(resultFunc).toThrow();
+        expect(resultFunc).toThrow("more rounds");
     });
 
     it("Should work with one round and one team in the ranking", () => {

--- a/__tests__/models/League.js
+++ b/__tests__/models/League.js
@@ -5,11 +5,10 @@ describe("generateContestantRoundScores", () => {
     it("Should work with simple defaults", () => {
         // Arrange
         const teamList  = [];
-        const rounds = 0;
         const sut = new League(teamList);
 
         // Act
-        const result = sut.generateContestantRoundScores(teamList, rounds, "");
+        const result = sut.generateContestantRoundScores(teamList, "");
 
         // Assert
         expect(result).not.toBeNull();
@@ -19,11 +18,10 @@ describe("generateContestantRoundScores", () => {
     it("Should throw an error when asking for more rounds then there are teams in the list", () => {
         // Arrange
         const teamList  = [];
-        const rounds = 1;
         const sut = new League(teamList);
 
         // Act
-        const resultFunc = () => sut.generateContestantRoundScores(teamList, rounds, "");
+        const resultFunc = () => sut.generateContestantRoundScores(teamList, "");
 
         // Assert
         expect(resultFunc).toThrow("more rounds");
@@ -32,11 +30,10 @@ describe("generateContestantRoundScores", () => {
     it("Should work with one round and one team in the ranking", () => {
         // Arrange
         const teamList = [new Team({teamName: "name1_1 & name1_2"})];
-        const rounds = 1;
         const sut = new League(teamList)
 
         // Act
-        const result = sut.generateContestantRoundScores(teamList, rounds, "");
+        const result = sut.generateContestantRoundScores(teamList, "");
 
         // Assert
         expect(result).not.toBeNull();
@@ -51,11 +48,10 @@ describe("generateContestantRoundScores", () => {
         let exampleTeam2 = new Team({teamName: "name2_1 & name2_2", isParticipating: true, eliminationOrder: 1});
 
         const teamList = [exampleTeam, exampleTeam2];
-        const rounds = 1;
         const sut = new League(teamList);
 
         // Act
-        const result = sut.generateContestantRoundScores(teamList, rounds, "");
+        const result = sut.generateContestantRoundScores(teamList, "");
 
         // Assert
         expect(result).not.toBeNull();
@@ -74,11 +70,10 @@ describe("generateContestantRoundScores", () => {
         let exampleTeam3 = new Team({teamName: "name2_1 & name2_2", isParticipating: true, eliminationOrder: 1});
 
         const teamList = [exampleTeam, exampleTeam2, exampleTeam3];
-        const rounds = 1;
         const sut = new League(teamList);
 
         // Act
-        const result = sut.generateContestantRoundScores(teamList, rounds, "");
+        const result = sut.generateContestantRoundScores(teamList, "");
 
         // Assert
         expect(result).not.toBeNull();
@@ -97,11 +92,10 @@ describe("generateContestantRoundScores", () => {
         let exampleTeam3 = new Team({teamName: "name2_1 & name2_2", isParticipating: true, eliminationOrder: 1});
 
         const teamList = [exampleTeam, exampleTeam2, exampleTeam3];
-        const rounds = 2;
         const sut = new League(teamList);
 
         // Act
-        const result = sut.generateContestantRoundScores(teamList, rounds, "");
+        const result = sut.generateContestantRoundScores(teamList, "");
 
         // Assert
         expect(result).not.toBeNull();

--- a/__tests__/models/League.js
+++ b/__tests__/models/League.js
@@ -261,7 +261,7 @@ describe("Regression Tests Checking Scoring of Archived Leagues", () => {
             return new Team(t);
         });
 
-        const numberOfRounds = 12;
+        const expectedNumberOfRounds = 12;
         const handicap = 0;
         const sut = new League(rachelsParsedAndEmbelishedTeamList);
 
@@ -269,7 +269,7 @@ describe("Regression Tests Checking Scoring of Archived Leagues", () => {
         const rachelsRoundScores = sut.generateContestantRoundScores(rachelsParsedAndEmbelishedTeamList, "testingRach", handicap);
 
         // Assert
-        expect(rachelsRoundScores.length).toBe(numberOfRounds);
+        expect(rachelsRoundScores.length).toBe(expectedNumberOfRounds);
 
 
         // Note: we are always pulling the 0th contestantRoundData because we
@@ -344,7 +344,7 @@ describe("Regression Tests Checking Scoring of Archived Leagues", () => {
             return new Team(t);
         });
 
-        const numberOfRounds = 12;
+        const expectedNumberOfRounds = 12;
         const handicap = 0;
         const sut = new League(anitasParsedAndEmbelishedTeamList);
 
@@ -352,7 +352,7 @@ describe("Regression Tests Checking Scoring of Archived Leagues", () => {
         const anitasRoundScores = sut.generateContestantRoundScores(anitasParsedAndEmbelishedTeamList, "testingAnita", handicap);
 
         // Assert
-        expect(anitasRoundScores.length).toBe(numberOfRounds);
+        expect(anitasRoundScores.length).toBe(expectedNumberOfRounds);
 
 
         // Note: we are always pulling the 0th contestantRoundData because we
@@ -428,7 +428,7 @@ describe("Regression Tests Checking Scoring of Archived Leagues", () => {
             return new Team(t);
         });
 
-        const numberOfRounds = 15;
+        const expectedNumberOfRounds = 15;
         const handicap = 0;
         const sut = new League(seansParsedAndEmbelishedTeamList);
 
@@ -436,7 +436,7 @@ describe("Regression Tests Checking Scoring of Archived Leagues", () => {
         const seansRoundScores = sut.generateContestantRoundScores(seansParsedAndEmbelishedTeamList, "testingSean", handicap);
 
         // Assert
-        expect(seansRoundScores.length).toBe(numberOfRounds);
+        expect(seansRoundScores.length).toBe(expectedNumberOfRounds);
 
         // Note: we are always pulling the 0th contestantRoundData because we
         // are only inserting on contestant into the league

--- a/__tests__/models/League.js
+++ b/__tests__/models/League.js
@@ -266,7 +266,7 @@ describe("Regression Tests Checking Scoring of Archived Leagues", () => {
         const sut = new League(rachelsParsedAndEmbelishedTeamList);
 
         // Act
-        const rachelsRoundScores = sut.generateContestantRoundScores(rachelsParsedAndEmbelishedTeamList, numberOfRounds, "testingRach", handicap);
+        const rachelsRoundScores = sut.generateContestantRoundScores(rachelsParsedAndEmbelishedTeamList, "testingRach", handicap);
 
         // Assert
         expect(rachelsRoundScores.length).toBe(numberOfRounds);
@@ -349,7 +349,7 @@ describe("Regression Tests Checking Scoring of Archived Leagues", () => {
         const sut = new League(anitasParsedAndEmbelishedTeamList);
 
         // Act
-        const anitasRoundScores = sut.generateContestantRoundScores(anitasParsedAndEmbelishedTeamList, numberOfRounds, "testingAnita", handicap);
+        const anitasRoundScores = sut.generateContestantRoundScores(anitasParsedAndEmbelishedTeamList, "testingAnita", handicap);
 
         // Assert
         expect(anitasRoundScores.length).toBe(numberOfRounds);
@@ -433,7 +433,7 @@ describe("Regression Tests Checking Scoring of Archived Leagues", () => {
         const sut = new League(seansParsedAndEmbelishedTeamList);
 
         // Act
-        const seansRoundScores = sut.generateContestantRoundScores(seansParsedAndEmbelishedTeamList, numberOfRounds, "testingSean", handicap);
+        const seansRoundScores = sut.generateContestantRoundScores(seansParsedAndEmbelishedTeamList, "testingSean", handicap);
 
         // Assert
         expect(seansRoundScores.length).toBe(numberOfRounds);

--- a/__tests__/models/League.js
+++ b/__tests__/models/League.js
@@ -17,11 +17,12 @@ describe("generateContestantRoundScores", () => {
 
     it("Should throw an error when asking for more rounds then there are teams in the list", () => {
         // Arrange
-        const teamList  = [];
+        const teamList  = [{name: "some team name"}];
+        const contestantTeamList = []
         const sut = new League(teamList);
 
         // Act
-        const resultFunc = () => sut.generateContestantRoundScores(teamList, "");
+        const resultFunc = () => sut.generateContestantRoundScores(contestantTeamList, "");
 
         // Assert
         expect(resultFunc).toThrow("more rounds");

--- a/__tests__/models/League.js
+++ b/__tests__/models/League.js
@@ -126,14 +126,13 @@ describe("addContestantRoundScores", () => {
     it("Should add multiple contestants to one rounds contestantRoundData per time add is called", () => {
         // Arrange
         const teamList = [exampleTeam, exampleTeam2, exampleTeam3];
-        const rounds = 1;
         const expectedContestantName1 = "contestant1";
         const expectedContestantName2 = "contestant2";
         const sut = new League(teamList);
 
         // Act
-        sut.addContestantRoundScores(teamList, rounds, expectedContestantName1);
-        sut.addContestantRoundScores(teamList, rounds, expectedContestantName2);
+        sut.addContestantRoundScores(teamList, expectedContestantName1);
+        sut.addContestantRoundScores(teamList, expectedContestantName2);
 
         // Assert
         expect(sut).not.toBeNull();
@@ -150,12 +149,11 @@ describe("addContestantRoundScores", () => {
     it("Should not break if handicap is not passed", () => {
         // Arrange
         const teamList = [exampleTeam, exampleTeam2, exampleTeam3];
-        const rounds = 1;
         const expectedContestantName1 = "contestant1";
         const sut = new League(teamList);
 
         // Act
-        sut.addContestantRoundScores(teamList, rounds, expectedContestantName1);
+        sut.addContestantRoundScores(teamList, expectedContestantName1);
 
         // Assert
         expect(sut).not.toBeNull();
@@ -171,13 +169,12 @@ describe("addContestantRoundScores", () => {
     it("Should modify totalScore if handicap is not passed", () => {
         // Arrange
         const teamList = [exampleTeam, exampleTeam2, exampleTeam3];
-        const rounds = 1;
         const expectedContestantName1 = "contestant1";
         const expectedHandicap = -10;
         const sut = new League(teamList);
 
         // Act
-        sut.addContestantRoundScores(teamList, rounds, expectedContestantName1, expectedHandicap);
+        sut.addContestantRoundScores(teamList, expectedContestantName1, expectedHandicap);
 
         // Assert
         expect(sut).not.toBeNull();

--- a/app/generators/contestantRoundListGenerator.tsx
+++ b/app/generators/contestantRoundListGenerator.tsx
@@ -30,7 +30,7 @@ export default async function generateListOfContestantRoundLists(
     const reverseTeamsList = [...pageData].reverse();
 
     const perfectScoreHandicap = 0;
-    const roundScores: IRound[] = League.generateContestantRoundScores(reverseTeamsList, numberOfRounds, "*perfect*", perfectScoreHandicap);
+    const roundScores: IRound[] = league.generateContestantRoundScores(reverseTeamsList, numberOfRounds, "*perfect*", perfectScoreHandicap);
 
     return listOfContestantLeagueData.map(contestant => {
         const currentSelectedContestantTeamsList = contestant.ranking.map((x: string) => {
@@ -39,7 +39,7 @@ export default async function generateListOfContestantRoundLists(
             return foundTeam;
         });
 
-        const contestantRoundScores: IRound[] = League.generateContestantRoundScores(currentSelectedContestantTeamsList, numberOfRounds, contestant.name, contestant.handicap);
+        const contestantRoundScores: IRound[] = league.generateContestantRoundScores(currentSelectedContestantTeamsList, numberOfRounds, contestant.name, contestant.handicap);
 
         return {
             key: contestant.name,

--- a/app/generators/contestantRoundListGenerator.tsx
+++ b/app/generators/contestantRoundListGenerator.tsx
@@ -25,12 +25,11 @@ export default async function generateListOfContestantRoundLists(
     }, {});
 
     const league = new League(pageData);
-    const numberOfRounds = league.getNumberOfRounds();
 
     const reverseTeamsList = [...pageData].reverse();
 
     const perfectScoreHandicap = 0;
-    const roundScores: IRound[] = league.generateContestantRoundScores(reverseTeamsList, numberOfRounds, "*perfect*", perfectScoreHandicap);
+    const roundScores: IRound[] = league.generateContestantRoundScores(reverseTeamsList, "*perfect*", perfectScoreHandicap);
 
     return listOfContestantLeagueData.map(contestant => {
         const currentSelectedContestantTeamsList = contestant.ranking.map((x: string) => {
@@ -39,7 +38,7 @@ export default async function generateListOfContestantRoundLists(
             return foundTeam;
         });
 
-        const contestantRoundScores: IRound[] = league.generateContestantRoundScores(currentSelectedContestantTeamsList, numberOfRounds, contestant.name, contestant.handicap);
+        const contestantRoundScores: IRound[] = league.generateContestantRoundScores(currentSelectedContestantTeamsList, contestant.name, contestant.handicap);
 
         return {
             key: contestant.name,

--- a/app/generators/contestantRoundScoreGenerator.tsx
+++ b/app/generators/contestantRoundScoreGenerator.tsx
@@ -22,7 +22,6 @@ export async function generateContestantRoundScores(
     }, {});
 
     const result: League = new League(pageData);
-    const numberOfRounds = result.getNumberOfRounds();
 
     listOfContestantLeagueData.map(contestant => {
 
@@ -31,7 +30,7 @@ export async function generateContestantRoundScores(
             return foundTeam;
         });
 
-        result.addContestantRoundScores(currentSelectedContestantTeamsList, numberOfRounds, contestant.name, contestant.handicap);
+        result.addContestantRoundScores(currentSelectedContestantTeamsList, contestant.name, contestant.handicap);
 
     });
 

--- a/app/models/League.tsx
+++ b/app/models/League.tsx
@@ -47,10 +47,15 @@ export default class League {
 
     addContestantRoundScores(contestantTeamsList: Team[], contestantName: string, handicap: number): void {
 
-        this.calculateContestantRoundScores(contestantTeamsList, contestantName, handicap, (roundNumber, elimOrder, countOfTeamsElimedThisFar, contestantLeagueData) => {
-            const currentRound = this.rounds[roundNumber]
-            currentRound.contestantRoundData.push(contestantLeagueData);
-        });
+        this.calculateContestantRoundScores(
+            contestantTeamsList,
+            contestantName,
+            handicap,
+            (roundNumber, elimOrder, countOfTeamsElimedThisFar, contestantLeagueData) => {
+                const currentRound = this.rounds[roundNumber]
+                currentRound.contestantRoundData.push(contestantLeagueData);
+            }
+        );
     }
 
     private calculateContestantRoundScores(
@@ -94,14 +99,19 @@ export default class League {
         }
 
         const result: IRound[] = [];
-        this.calculateContestantRoundScores(contestantTeamsList, contestantName, handicap, (roundNumber, elimOrder, teamsElimedSoFar, contestantLeagueData) => {
-            result.push({
-                round: roundNumber,
-                eliminationOrder: elimOrder,
-                teamsEliminatedSoFar: teamsElimedSoFar,
-                contestantRoundData: [contestantLeagueData]
-            });
-        });
+        this.calculateContestantRoundScores(
+            contestantTeamsList,
+            contestantName,
+            handicap,
+            (roundNumber, elimOrder, teamsElimedSoFar, contestantLeagueData) => {
+                result.push({
+                    round: roundNumber,
+                    eliminationOrder: elimOrder,
+                    teamsEliminatedSoFar: teamsElimedSoFar,
+                    contestantRoundData: [contestantLeagueData]
+                });
+            }
+        );
 
         return result;
     }

--- a/app/models/League.tsx
+++ b/app/models/League.tsx
@@ -89,7 +89,7 @@ export default class League {
 
     generateContestantRoundScores(contestantTeamsList: Team[], contestantName: string, handicap: number): IRound[] {
 
-        if (numberOfRounds > contestantTeamsList.length) {
+        if (this.numberOfRounds > contestantTeamsList.length) {
             throw new Error("Asking for more rounds that the number of teams in the list");
         }
 

--- a/app/models/League.tsx
+++ b/app/models/League.tsx
@@ -47,7 +47,7 @@ export default class League {
 
     addContestantRoundScores(contestantTeamsList: Team[], numberOfRounds: number, contestantName: string, handicap: number): void {
 
-        this.calculateContestantRoundScores(contestantTeamsList, numberOfRounds, contestantName, handicap, (roundNumber, elimOrder, countOfTeamsElimedThisFar, contestantLeagueData) => {
+        this.calculateContestantRoundScores(contestantTeamsList, contestantName, handicap, (roundNumber, elimOrder, countOfTeamsElimedThisFar, contestantLeagueData) => {
             const currentRound = this.rounds[roundNumber]
             currentRound.contestantRoundData.push(contestantLeagueData);
         });
@@ -55,13 +55,13 @@ export default class League {
 
     private calculateContestantRoundScores(
         contestantTeamsList: Team[],
-        numberOfRounds: number,
         contestantName: string,
         handicap: number,
         addToRoundList: (_n: number, _eo: number, _cot: number, _crd: IContestantRoundData) => void
     ): void {
 
         let grandTotal = handicap === undefined ? 0 : handicap;
+        const numberOfRounds = this.getNumberOfRounds();
         for(let i = 0; i < numberOfRounds; i++) {
             const currentRound = this.rounds[i];
             const elimOrder = currentRound.eliminationOrder;
@@ -94,7 +94,7 @@ export default class League {
         }
 
         const result: IRound[] = [];
-        this.calculateContestantRoundScores(contestantTeamsList, numberOfRounds, contestantName, handicap, (roundNumber, elimOrder, teamsElimedSoFar, contestantLeagueData) => {
+        this.calculateContestantRoundScores(contestantTeamsList, contestantName, handicap, (roundNumber, elimOrder, teamsElimedSoFar, contestantLeagueData) => {
             result.push({
                 round: roundNumber,
                 eliminationOrder: elimOrder,

--- a/app/models/League.tsx
+++ b/app/models/League.tsx
@@ -47,27 +47,10 @@ export default class League {
 
     addContestantRoundScores(contestantTeamsList: Team[], numberOfRounds: number, contestantName: string, handicap: number): void {
 
-        let grandTotal = handicap === undefined ? 0 : handicap;
-        for(let i = 0; i < numberOfRounds; i++) {
-            const currentRound = this.rounds[i];
-            const elimOrder = currentRound.eliminationOrder;
-            const countOfTeamsElimedThisFar = currentRound.teamsEliminatedSoFar;
-            const roundScore = contestantTeamsList.reduce(
-                (acc: number, x: Team) => {
-                    const teamShouldBeScored = shouldBeScored(contestantTeamsList, x, elimOrder, countOfTeamsElimedThisFar);
-    
-                    return teamShouldBeScored ? acc + 10 : acc;
-                }, 0);
-
-            grandTotal += roundScore;
-
-            currentRound.contestantRoundData.push({
-                name: contestantName,
-                roundScore: roundScore,
-                totalScore: grandTotal
-            });
-
-        }
+        this.calculateContestantRoundScores(contestantTeamsList, numberOfRounds, contestantName, handicap, (roundNumber, elimOrder, countOfTeamsElimedThisFar, contestantLeagueData) => {
+            const currentRound = this.rounds[roundNumber]
+            currentRound.contestantRoundData.push(contestantLeagueData);
+        });
     }
 
     private calculateContestantRoundScores(
@@ -111,10 +94,10 @@ export default class League {
         }
 
         const result: IRound[] = [];
-        this.calculateContestantRoundScores(contestantTeamsList, numberOfRounds, contestantName, handicap, (roundNumber, eliminationOrder, teamsElimedSoFar, contestantLeagueData) => {
+        this.calculateContestantRoundScores(contestantTeamsList, numberOfRounds, contestantName, handicap, (roundNumber, elimOrder, teamsElimedSoFar, contestantLeagueData) => {
             result.push({
                 round: roundNumber,
-                eliminationOrder: eliminationOrder,
+                eliminationOrder: elimOrder,
                 teamsEliminatedSoFar: teamsElimedSoFar,
                 contestantRoundData: [contestantLeagueData]
             });

--- a/app/models/League.tsx
+++ b/app/models/League.tsx
@@ -45,7 +45,7 @@ export default class League {
         }
     }
 
-    addContestantRoundScores(contestantTeamsList: Team[], numberOfRounds: number, contestantName: string, handicap: number): void {
+    addContestantRoundScores(contestantTeamsList: Team[], contestantName: string, handicap: number): void {
 
         this.calculateContestantRoundScores(contestantTeamsList, contestantName, handicap, (roundNumber, elimOrder, countOfTeamsElimedThisFar, contestantLeagueData) => {
             const currentRound = this.rounds[roundNumber]

--- a/app/models/League.tsx
+++ b/app/models/League.tsx
@@ -110,10 +110,18 @@ export default class League {
             throw new Error("Asking for more rounds that the number of teams in the list");
         }
 
-        const result = new League(contestantTeamsList);
-        result.addContestantRoundScores(contestantTeamsList, numberOfRounds, contestantName, handicap);
+        const league = new League(contestantTeamsList);
+        const result: IRound[] = [];
+        league.calculateContestantRoundScores(contestantTeamsList, numberOfRounds, contestantName, handicap, (roundNumber, eliminationOrder, teamsElimedSoFar, contestantLeagueData) => {
+            result.push({
+                round: roundNumber,
+                eliminationOrder: eliminationOrder,
+                teamsEliminatedSoFar: teamsElimedSoFar,
+                contestantRoundData: [contestantLeagueData]
+            });
+        });
 
-        return result.rounds;
+        return result;
     }
 } 
 

--- a/app/models/League.tsx
+++ b/app/models/League.tsx
@@ -1,4 +1,5 @@
 import IRound from "./IRound";
+import IContestantRoundData from "./IContestantRoundData";
 import Team from "./Team";
 import { shouldBeScored, getNumberOfTeamsToEliminate, getRoundEliminationOrderMapping, getUniqueEliminationOrders } from "../utils/teamListUtils";
 
@@ -66,6 +67,33 @@ export default class League {
                 totalScore: grandTotal
             });
 
+        }
+    }
+
+    private calculateContestantRoundScores(
+        contestantTeamsList: Team[],
+        numberOfRounds: number,
+        contestantName: string,
+        handicap: number,
+        addToRoundList: (_n: number, _crd: IContestantRoundData) => void
+    ): void {
+
+        let grandTotal = handicap === undefined ? 0 : handicap;
+        for(let i = 0; i < numberOfRounds; i++) {
+            const roundScore = contestantTeamsList.reduce(
+                (acc: number, x: Team) => {
+                    const teamShouldBeScored = shouldBeScored(contestantTeamsList, x, i);
+    
+                    return teamShouldBeScored ? acc + 10 : acc;
+                }, 0);
+
+            grandTotal += roundScore;
+
+            addToRoundList(i, {
+                name: contestantName,
+                roundScore: roundScore,
+                totalScore: grandTotal
+            });
         }
     }
 

--- a/app/models/League.tsx
+++ b/app/models/League.tsx
@@ -104,15 +104,14 @@ export default class League {
         return this.numberOfRounds;
     }
 
-    static generateContestantRoundScores(contestantTeamsList: Team[], numberOfRounds: number, contestantName: string, handicap: number): IRound[] {
+    generateContestantRoundScores(contestantTeamsList: Team[], numberOfRounds: number, contestantName: string, handicap: number): IRound[] {
 
         if (numberOfRounds > contestantTeamsList.length) {
             throw new Error("Asking for more rounds that the number of teams in the list");
         }
 
-        const league = new League(contestantTeamsList);
         const result: IRound[] = [];
-        league.calculateContestantRoundScores(contestantTeamsList, numberOfRounds, contestantName, handicap, (roundNumber, eliminationOrder, teamsElimedSoFar, contestantLeagueData) => {
+        this.calculateContestantRoundScores(contestantTeamsList, numberOfRounds, contestantName, handicap, (roundNumber, eliminationOrder, teamsElimedSoFar, contestantLeagueData) => {
             result.push({
                 round: roundNumber,
                 eliminationOrder: eliminationOrder,

--- a/app/models/League.tsx
+++ b/app/models/League.tsx
@@ -87,7 +87,7 @@ export default class League {
         return this.numberOfRounds;
     }
 
-    generateContestantRoundScores(contestantTeamsList: Team[], numberOfRounds: number, contestantName: string, handicap: number): IRound[] {
+    generateContestantRoundScores(contestantTeamsList: Team[], contestantName: string, handicap: number): IRound[] {
 
         if (numberOfRounds > contestantTeamsList.length) {
             throw new Error("Asking for more rounds that the number of teams in the list");

--- a/app/models/League.tsx
+++ b/app/models/League.tsx
@@ -75,21 +75,24 @@ export default class League {
         numberOfRounds: number,
         contestantName: string,
         handicap: number,
-        addToRoundList: (_n: number, _crd: IContestantRoundData) => void
+        addToRoundList: (_n: number, _eo: number, _cot: number, _crd: IContestantRoundData) => void
     ): void {
 
         let grandTotal = handicap === undefined ? 0 : handicap;
         for(let i = 0; i < numberOfRounds; i++) {
+            const currentRound = this.rounds[i];
+            const elimOrder = currentRound.eliminationOrder;
+            const countOfTeamsElimedThisFar = currentRound.teamsEliminatedSoFar;
             const roundScore = contestantTeamsList.reduce(
                 (acc: number, x: Team) => {
-                    const teamShouldBeScored = shouldBeScored(contestantTeamsList, x, i);
-    
+                    const teamShouldBeScored = shouldBeScored(contestantTeamsList, x, elimOrder, countOfTeamsElimedThisFar);
+
                     return teamShouldBeScored ? acc + 10 : acc;
                 }, 0);
 
             grandTotal += roundScore;
 
-            addToRoundList(i, {
+            addToRoundList(i, elimOrder, countOfTeamsElimedThisFar, {
                 name: contestantName,
                 roundScore: roundScore,
                 totalScore: grandTotal


### PR DESCRIPTION
### Summary/Acceptance Criteria
This accomplishes exactly what is described in the issue. Between the description of issue #267 and the description of PR #243 I hope it is clear what this PR is hoping to achieve and how it is hoping to do that.

### Changes to look for (pulled and revised from #243)

- Made generateContestantRoundScores an instance method (in order to leverage a ~memoized~ pre-calculated numberOfRouds)
- ~Memoized the numberOfRounds (meaning we no longer need to precalculate it)~ _(this is no longer necessary because it's pre-calculated)_
- Remove all passing around and precalculating of numberOfRounds


### Screenshots
N/A since this this a perf refactor...
However here are some just-in-time compilation results when running `npm run dev`

Before: (this one util method would be called 80 times for just the scoring page basically being called for every round (8) for every contestant (8) plus two more (once for `League` creation and once for the "perfect" score generation)) (8 * (8 + 1 + 1) = 80)
![image](https://github.com/user-attachments/assets/535bd039-4486-49fc-a51b-c194a58d054a)

After: (is now just called once per round for the whole page): 8
![image](https://github.com/user-attachments/assets/d5cea9ec-fc63-43a4-8def-94a14ff043f4)

## Confirm
- [ ] This PR has unit tests scenarios. (N/A no new functional behavior)
- [x] This PR is correctly linked to the relevant issue or milestone.
- [x] This PR has been locally QA'd.
- [ ] This PR has had it's db migrations run. (N/A no new data here)

/assign me
