### PR TITLE
238 calculating eliminationorder at the end of amazingrace is slopy

### DIFF
--- a/__tests__/utils/wikiQuery.js
+++ b/__tests__/utils/wikiQuery.js
@@ -741,3 +741,7 @@ describe("getCompetingEntityList", () => {
         expect(result.map(x => x.eliminationOrder)).not.toContain(0);
     });
 });
+
+describe("stripTableHeader", () => {
+
+});

--- a/__tests__/utils/wikiQuery.js
+++ b/__tests__/utils/wikiQuery.js
@@ -1,4 +1,4 @@
-import { getTeamList, isPartialContestantData, getCompetingEntityList } from "../../app/utils/wikiQuery";
+import { getTeamList, isPartialContestantData, getCompetingEntityList, stripTableHeader } from "../../app/utils/wikiQuery";
 
 describe("getTeamList", () => {
     it("should run", () => {

--- a/__tests__/utils/wikiQuery.js
+++ b/__tests__/utils/wikiQuery.js
@@ -746,5 +746,23 @@ describe("stripTableHeader", () => {
 
     it("Should stip a known header row out of a list of tableRowData", () => {
 
+        // Arrange
+        const knownHeaderRow = {
+            name: "",
+            name2: "Contestants\nAge\nRelationship\nHometown\nStatus",
+            col1: "",
+            col2: "",
+            col3: "",
+            col4: "",
+            col5: ""
+        };
+        const tableRowDataList = [knownHeaderRow];
+
+        // Act
+        const result = stripTableHeader(tableRowDataList);
+
+        // Assert
+        expect(result).not.toBeNull();
+        expect(result.length).toBe(0);
     });
 });

--- a/__tests__/utils/wikiQuery.js
+++ b/__tests__/utils/wikiQuery.js
@@ -744,7 +744,7 @@ describe("getCompetingEntityList", () => {
 
 describe("stripTableHeader", () => {
 
-    it("Should stip a known header row out of a list of tableRowData", () => {
+    it("Should strip a known header row out of a list of tableRowData", () => {
 
         // Arrange
         const knownHeaderRow = {

--- a/__tests__/utils/wikiQuery.js
+++ b/__tests__/utils/wikiQuery.js
@@ -787,4 +787,26 @@ describe("stripTableHeader", () => {
         expect(result).not.toBeNull();
         expect(result.length).toBe(1);
     });
+
+    it("Should not strip a knwon good row with partially populated contetantData", () => {
+
+        // Arrange
+        const knownGoodRow = {
+            name: "John Franklin",
+            name2: "John Franklin",
+            col1: "27",
+            col2: "Mountain View, California",
+            col3: "",
+            col4: "",
+            col5: ""
+        };
+        const tableRowDataList = [knownGoodRow];
+
+        // Act
+        const result = stripTableHeader(tableRowDataList);
+
+        // Assert
+        expect(result).not.toBeNull();
+        expect(result.length).toBe(1);
+    });
 });

--- a/__tests__/utils/wikiQuery.js
+++ b/__tests__/utils/wikiQuery.js
@@ -765,4 +765,26 @@ describe("stripTableHeader", () => {
         expect(result).not.toBeNull();
         expect(result.length).toBe(0);
     });
+
+    it("Should not strip a knwon good row with 'fully' populated contetantData", () => {
+
+        // Arrange
+        const knownGoodRow = {
+            name: "Greg Franklin",
+            name2: "Greg Franklin",
+            col1: "25",
+            col2: "Brothers & Computer Scientists",
+            col3: "New York City, New York",
+            col4: "Winners",
+            col5: ""
+        };
+        const tableRowDataList = [knownGoodRow];
+
+        // Act
+        const result = stripTableHeader(tableRowDataList);
+
+        // Assert
+        expect(result).not.toBeNull();
+        expect(result.length).toBe(1);
+    });
 });

--- a/__tests__/utils/wikiQuery.js
+++ b/__tests__/utils/wikiQuery.js
@@ -744,4 +744,7 @@ describe("getCompetingEntityList", () => {
 
 describe("stripTableHeader", () => {
 
+    it("Should stip a known header row out of a list of tableRowData", () => {
+
+    });
 });

--- a/app/generators/contestantRoundListGenerator.tsx
+++ b/app/generators/contestantRoundListGenerator.tsx
@@ -15,7 +15,10 @@ export default async function generateListOfContestantRoundLists(
     listOfContestantLeagueData: IContestantData[],
     getCompetingEntityListFunction: (_: ITableRowData[]) => Team[] = getTeamList,
 ) {
-    const wikiContestants = await dataFetcher();
+    const wikiTableData = await dataFetcher();
+
+    const wikiContestants = stripTableHeader(wikiTableData);
+
     const pageData = getCompetingEntityListFunction(wikiContestants);
 
     const teamDictionary = pageData.reduce((acc: Dictionary<Team>, t: Team) => {

--- a/app/generators/contestantRoundListGenerator.tsx
+++ b/app/generators/contestantRoundListGenerator.tsx
@@ -1,4 +1,4 @@
-import { getTeamList } from "../utils/wikiQuery";
+import { getTeamList, stripTableHeader } from "../utils/wikiQuery";
 import { IContestantData } from "@/app/dataSources/dbFetch";
 import { ITableRowData } from "../dataSources/wikiFetch";
 import Team from "../models/Team";

--- a/app/generators/contestantRoundScoreGenerator.tsx
+++ b/app/generators/contestantRoundScoreGenerator.tsx
@@ -13,9 +13,11 @@ export async function generateContestantRoundScores(
     getCompetitorList: (_: ITableRowData[]) => Team[],
     listOfContestantLeagueData: IContestantData[]
 ) {
-    const wikiData = await dataFetcher();
+    const wikiTableData = await dataFetcher();
+
+    const wikiContestants = stripTableHeader(wikiTableData);
     // TODO: come up with better names for getCompetitorList and pageData
-    const pageData = getCompetitorList(wikiData);
+    const pageData = getCompetitorList(wikiContestants);
     const teamDictionary = pageData.reduce((acc: Dictionary<Team>, t: Team) => {
         acc[Team.getKey(t.teamName)] = t;
 

--- a/app/generators/contestantRoundScoreGenerator.tsx
+++ b/app/generators/contestantRoundScoreGenerator.tsx
@@ -1,4 +1,5 @@
 import { ITableRowData } from "../dataSources/wikiFetch";
+import { stripTableHeader } from "@/app/utils/wikiQuery";
 import { IContestantData } from "@/app/dataSources/dbFetch";
 import Team from "../models/Team";
 import League from "../models/League";

--- a/app/utils/wikiQuery.tsx
+++ b/app/utils/wikiQuery.tsx
@@ -192,7 +192,7 @@ export function getCompetingEntityList(contestantData :ITableRowData[]): Team[] 
     return contestantsSortedByEliminationOrder;
 }
 
-export function stripTableHeader(competingEntityData :ITableRowData[]) {
+export function stripTableHeader(competingEntityData :ITableRowData[]): ITableRowData[] {
     return competingEntityData.filter(x => {
         return !(x.name === ""
             && (x.name2.includes("\n")

--- a/app/utils/wikiQuery.tsx
+++ b/app/utils/wikiQuery.tsx
@@ -191,3 +191,21 @@ export function getCompetingEntityList(contestantData :ITableRowData[]): Team[] 
 
     return contestantsSortedByEliminationOrder;
 }
+
+export function stripTableHeader(competingEntityData :ITableRowData[]) {
+    return competingEntityData.filter(x => {
+        return !(x.name === ""
+            && (x.name2.includes("\n")
+                || x.name2.includes("Contestants")
+                || x.name2.includes("Age")
+                || x.name2.includes("Relationship")
+                || x.name2.includes("Hometown")
+                || x.name2.includes("Status"))
+            && x.col1 === ""
+            && x.col2 === ""
+            && x.col3 === ""
+            && x.col4 === ""
+            && x.col5 === "");
+    });
+}
+


### PR DESCRIPTION
### Summary/Acceptance Criteria
This accomplishes exactly what it's attached issue is suggesting.

### Screenshots
(N/A since there is no UI difference)

Before:
![image](https://github.com/user-attachments/assets/41eaf04c-07e9-498c-82aa-da5d84ecc3c4)

After:
![image](https://github.com/user-attachments/assets/c03c428f-e08b-408f-bd25-6878b8cc13e2)

## Confirm
- [x] This PR has unit tests scenarios.
- [x] This PR is correctly linked to the relevant issue or milestone.
- [x] This PR has been locally QA'd.
- [ ] This PR has had it's db migrations run. (N/A no new data here)

/assign me
