### PR TITLE
Feature/create parser switcher

### DIFF
--- a/__tests__/utils/entityParserSwitch.js
+++ b/__tests__/utils/entityParserSwitch.js
@@ -1,0 +1,27 @@
+import { getParser } from "@/app/utils/entityParserSwitch"
+
+describe("getParser", () => {
+
+    it("Should return a parser which can handle 'eliminated' status for amazingRace", () => {
+
+        // Arrange
+        const tableRowData = [
+            {
+                name: "Some person",
+                col4: "Eliminated 4th"
+            }
+        ];
+
+        // Act
+        const parserSutFn = getParser("amazing_race");
+
+        const parsedEntities = parserSutFn(tableRowData);
+
+        // Assert
+        expect(parsedEntities).not.toBeNull();
+        expect(parsedEntities.length).toBe(1);
+        expect(parsedEntities[0].isParticipating).toBeFalsy();
+        expect(parsedEntities[0].eliminationOrder).toBe(4);
+    });
+
+});

--- a/__tests__/utils/entityParserSwitch.js
+++ b/__tests__/utils/entityParserSwitch.js
@@ -2,7 +2,7 @@ import { getParser } from "@/app/utils/entityParserSwitch"
 
 describe("getParser", () => {
 
-    it("Should return a parser which can handle 'eliminated' status for amazingRace", () => {
+    it("Should return a parser which can handle 'eliminated' status for amazing_race", () => {
 
         // Arrange
         const tableRowData = [
@@ -24,7 +24,7 @@ describe("getParser", () => {
         expect(parsedEntities[0].eliminationOrder).toBe(4);
     });
 
-    it("Should return a parser which can colate teams for amazingRace", () => {
+    it("Should return a parser which can colate teams for amazing_race", () => {
 
         // Arrange
         const tableRowData = [

--- a/__tests__/utils/entityParserSwitch.js
+++ b/__tests__/utils/entityParserSwitch.js
@@ -73,4 +73,30 @@ describe("getParser", () => {
         expect(parsedEntities).not.toBeNull();
         expect(parsedEntities.length).toBe(2);
     });
+
+    it("Should return a parser which can handle 'evicted' for big_brother", () => {
+
+        // Arrange
+        const tableRowData = [
+            {
+                name: "Some person",
+                col4: "EvictedDay 10"
+            },
+            {
+                name: "Some personsbrother",
+                col4: "Winner"
+            }
+        ];
+
+        // Act
+        const parserSutFn = getParser("big_brother");
+
+        const parsedEntities = parserSutFn(tableRowData);
+
+        // Assert
+        expect(parsedEntities).not.toBeNull();
+        expect(parsedEntities.length).toBe(2);
+        expect(parsedEntities[0].isParticipating).toBeFalsy();
+        expect(parsedEntities[0].eliminationOrder).toBe(1);
+    });
 });

--- a/__tests__/utils/entityParserSwitch.js
+++ b/__tests__/utils/entityParserSwitch.js
@@ -24,4 +24,30 @@ describe("getParser", () => {
         expect(parsedEntities[0].eliminationOrder).toBe(4);
     });
 
+    it("Should return a parser which can colate teams for amazingRace", () => {
+
+        // Arrange
+        const tableRowData = [
+            {
+                name: "Some person",
+                col4: "Eliminated 4th"
+            },
+            {
+                name: "Some personsbrother",
+                col4: ""
+            }
+        ];
+
+        // Act
+        const parserSutFn = getParser("amazing_race");
+
+        const parsedEntities = parserSutFn(tableRowData);
+
+        // Assert
+        expect(parsedEntities).not.toBeNull();
+        expect(parsedEntities.length).toBe(1); // main test
+        expect(parsedEntities[0].isParticipating).toBeFalsy();
+        expect(parsedEntities[0].eliminationOrder).toBe(4);
+    });
+
 });

--- a/__tests__/utils/entityParserSwitch.js
+++ b/__tests__/utils/entityParserSwitch.js
@@ -50,4 +50,27 @@ describe("getParser", () => {
         expect(parsedEntities[0].eliminationOrder).toBe(4);
     });
 
+    it("Should return a parser which creates an entity per row for big_brother", () => {
+
+        // Arrange
+        const tableRowData = [
+            {
+                name: "Some person",
+                col4: "Eliminated 4th"
+            },
+            {
+                name: "Some personsbrother",
+                col4: ""
+            }
+        ];
+
+        // Act
+        const parserSutFn = getParser("big_brother");
+
+        const parsedEntities = parserSutFn(tableRowData);
+
+        // Assert
+        expect(parsedEntities).not.toBeNull();
+        expect(parsedEntities.length).toBe(2);
+    });
 });

--- a/app/[showStatus]/[showNameAndSeason]/contestants/page.tsx
+++ b/app/[showStatus]/[showNameAndSeason]/contestants/page.tsx
@@ -1,5 +1,4 @@
-import parseAmazingRaceEntities from "@/app/parsers/amazingRaceEntityParser";
-import parseBigBrotherEntities from "@/app/parsers/bigBrotherEntityParser";
+import { parseEntities } from "@/app/utils/entityParserSwitch"
 import { getWikipediaContestantData } from "../../../dataSources/wikiFetch";
 import { getLeagueConfigurationData, getLeagueConfigurationKeys } from "@/app/dataSources/dbFetch";
 import { getUrlParams } from "@/app/utils/pages";
@@ -33,12 +32,8 @@ export default async function Contestants({ params }: {
     const { wikiApiUrl, wikiPageUrl, castPhrase, competitingEntityName } = leagueConfigurationData;
 
     const wikiContestants = await getWikipediaContestantData(wikiApiUrl, castPhrase);
-    let final;
-    if(showName.match("amazing_race")){
-        final = parseAmazingRaceEntities(wikiContestants);
-    } else {
-        final = parseBigBrotherEntities(wikiContestants);
-    }
+
+    const final = parseEntities(wikiContestants, showName);
 
     return (
         <div>

--- a/app/[showStatus]/[showNameAndSeason]/league-standing/page.tsx
+++ b/app/[showStatus]/[showNameAndSeason]/league-standing/page.tsx
@@ -1,7 +1,6 @@
 import { getWikipediaContestantDataFetcher } from "@/app/dataSources/wikiFetch"
 import LeagueStandingTable from "../../../components/leagueStandingTable/leagueStandingTable";
-import parseAmazingRaceEntities from "@/app/parsers/amazingRaceEntityParser";
-import parseBigBrotherEntities from "@/app/parsers/bigBrotherEntityParser";
+import { getParser } from "@/app/utils/entityParserSwitch"
 import { generateContestantRoundScores } from "@/app/generators/contestantRoundScoreGenerator";
 import { getContestantData, getLeagueConfigurationKeys, getLeagueConfigurationData } from "@/app/dataSources/dbFetch";
 import { getUrlParams } from "@/app/utils/pages";
@@ -32,9 +31,9 @@ export default async function LeagueStanding({ params }: {
     const dataFetcher = getWikipediaContestantDataFetcher(wikiApiUrl, castPhrase);
     const contestantRoundData = await getContestantData(contestantLeagueDataKeyPrefix);
 
-    const getEntityFn = showName.match("amazing_race") ? parseAmazingRaceEntities : parseBigBrotherEntities;
+    const parsingFn = getParser(showName)
     
-    const contestantsScores = await generateContestantRoundScores(dataFetcher, getEntityFn, contestantRoundData);
+    const contestantsScores = await generateContestantRoundScores(dataFetcher, parsingFn, contestantRoundData);
     return (
         <div>
             <h1 className="text-3xl text-center">League Standing</h1>

--- a/app/[showStatus]/[showNameAndSeason]/scoring/page.tsx
+++ b/app/[showStatus]/[showNameAndSeason]/scoring/page.tsx
@@ -1,6 +1,5 @@
 import ContestantSelector from "../../../components/contestantSelector"
-import parseAmazingRaceEntities from "@/app/parsers/amazingRaceEntityParser";
-import parseBigBrotherEntities from "@/app/parsers/bigBrotherEntityParser";
+import { getParser } from "@/app/utils/entityParserSwitch"
 import { getWikipediaContestantDataFetcher } from "../../../dataSources/wikiFetch"
 import generateListOfContestantRoundLists from "../../../generators/contestantRoundListGenerator"
 import { getContestantData, getLeagueConfigurationKeys, getLeagueConfigurationData } from "@/app/dataSources/dbFetch"
@@ -31,16 +30,11 @@ export default async function Scoring({ params }: {
     const { wikiApiUrl, googleSheetUrl, castPhrase, preGoogleSheetsLinkText, postGoogleSheetsLinkText, contestantLeagueDataKeyPrefix } = leagueConfigurationData;
 
     const dataFetcher = getWikipediaContestantDataFetcher(wikiApiUrl, castPhrase);
-    let listOfContestantRoundLists;
 
     const contestantRoundData = await getContestantData(contestantLeagueDataKeyPrefix);
 
-    // Check for Amazing Race due to additional param
-    if(showName.match("amazing_race")){
-        listOfContestantRoundLists = await generateListOfContestantRoundLists(dataFetcher, contestantRoundData, parseAmazingRaceEntities)
-    } else {
-        listOfContestantRoundLists = await generateListOfContestantRoundLists(dataFetcher, contestantRoundData, parseBigBrotherEntities)
-    }
+    const parsingFn = getParser(showName)
+    const listOfContestantRoundLists = await generateListOfContestantRoundLists(dataFetcher, contestantRoundData, parsingFn)
 
     return (
         <div>

--- a/app/utils/entityParserSwitch.tsx
+++ b/app/utils/entityParserSwitch.tsx
@@ -1,0 +1,13 @@
+import { ITableRowData } from "@/app/dataSources/wikiFetch";
+import CompetingEntity from "@/app/models/CompetingEntity";
+import parseAmazingRaceEntities from "@/app/parsers/amazingRaceEntityParser";
+import parseBigBrotherEntities from "@/app/parsers/bigBrotherEntityParser";
+
+export function getParser(showName: string): (_itrd: ITableRowData[]) => CompetingEntity[] {
+
+    if (showName.match("amazing_race")) {
+        return parseAmazingRaceEntities;
+    } else {
+        return parseBigBrotherEntities;
+    }
+}

--- a/app/utils/entityParserSwitch.tsx
+++ b/app/utils/entityParserSwitch.tsx
@@ -3,6 +3,14 @@ import CompetingEntity from "@/app/models/CompetingEntity";
 import parseAmazingRaceEntities from "@/app/parsers/amazingRaceEntityParser";
 import parseBigBrotherEntities from "@/app/parsers/bigBrotherEntityParser";
 
+export function parseEntities(contestantData: ITableRowData[], showName: string ): CompetingEntity[] {
+
+    const parserFn = getParser(showName);
+    const result =  parserFn(contestantData);
+
+    return result;
+}
+
 export function getParser(showName: string): (_itrd: ITableRowData[]) => CompetingEntity[] {
 
     if (showName.match("amazing_race")) {


### PR DESCRIPTION
### Summary/Acceptance Criteria
Now that we have clearly articulated parsers since they have to parse different tables (#281 & #282), we can now put all of those into a abstract factory pattern of sorts where we can switch off the specific parser used based on which show we are concerned with. This PR does that and it creates the `getParser` function for the scoring and league standing page where all we need to do is to get the parser. Then we also add a `parseEntities` function which will select the parser based on a `showName` and execute it returning `CompetingEntities[]`

### Screenshots
(N/A just a backend refactor)

## Confirm
- [x] This PR has unit tests scenarios. (Added only a few to test `getParser` I figured `parseEntities` is really just a helper and it seemed like writing unit tests for that more tedious than helpful)
- [x] This PR is correctly linked to the relevant issue or milestone.
- [x] This PR has been locally QA'd.
- [ ] This PR has had it's db migrations run. (N/A no new data in this PR)

/assign me
