### PR TITLE
Feature/add cols on wikifetch

### DIFF
--- a/app/dataSources/wikiFetch.tsx
+++ b/app/dataSources/wikiFetch.tsx
@@ -89,6 +89,8 @@ export async function getWikipediaContestantData(wikiUrl: string, contestantSect
         const col3 = $row.find("td").eq(2).text().trim();
         const col4 = $row.find("td").eq(3).text().trim();
         const col5 = $row.find("td").eq(4).text().trim();
+        const col6 = $row.find("td").eq(5).text().trim();
+        const col7 = $row.find("td").eq(6).text().trim();
 
         const aContestant: ITableRowData = {
             name: name,
@@ -97,7 +99,9 @@ export async function getWikipediaContestantData(wikiUrl: string, contestantSect
             col2: col2,
             col3: col3,
             col4: col4,
-            col5: col5
+            col5: col5,
+            col6: col6,
+            col7: col7
         };
 
         return aContestant;

--- a/app/dataSources/wikiFetch.tsx
+++ b/app/dataSources/wikiFetch.tsx
@@ -33,6 +33,8 @@ export interface ITableRowData {
     col3: string
     col4: string
     col5: string
+    col6: string
+    col7: string
 }
 
 async function fetchWikipediaData(wikiUrl: string): Promise<IWikipediaData> {


### PR DESCRIPTION
### Summary/Acceptance Criteria
When starting to look into the tables in the Survivor pages, I noticed that those tables are even more complicated. In some cases they have two more columns. So this adds a `col6` & `col7` to our ITableRowData` model to use in our parsing.

### Screenshots
(N/A this is just updating our wiki scraping "integration")

## Confirm
- [ ] This PR has unit tests scenarios. (N/A we don't typically write tests for this integration)
- [x] This PR is correctly linked to the relevant issue or milestone.
- [x] This PR has been locally QA'd.
- [ ] This PR has had it's db migrations run. (N/A no new data in this PR)

/assign me
