### PR TITLE
295 add set of regression tests for the season

### DIFF
--- a/__tests__/generators/contestantRoundScoreGenerator.js
+++ b/__tests__/generators/contestantRoundScoreGenerator.js
@@ -1,6 +1,7 @@
 import { generateContestantRoundScores } from "@/app/generators/contestantRoundScoreGenerator"
 import parseBigBrotherEntities from "@/app/parsers/bigBrotherEntityParser";
 import parseAmazingRaceEntities from "@/app/parsers/amazingRaceEntityParser";
+import parseSurvivorEntities from "@/app/parsers/survivorEntityParser";
 
 describe("Regression Tests Checking generation of Archived Leagues", () => {
 
@@ -177,5 +178,48 @@ describe("Regression Tests Checking generation of Archived Leagues", () => {
         expect(result.rounds[14].contestantRoundData[0].name).toBe(seansContestantLeagueData.name);
         expect(result.rounds[14].contestantRoundData[0].roundScore).toBe(0);
         expect(result.rounds[14].contestantRoundData[0].totalScore).toBe(730);
+    });
+
+    it("Should return a league with Antoinettes scoring for Survivor_47", async () => {
+
+        // Arrange
+        const testDataFetcher = () => new Promise((resolve, _reject) => {
+            resolve(
+                [ { name: "", name2: "Contestant\nAge\nFrom\nTribe\nFinish", col1: "", col2: "", col3: "", col4: "", col5: "", col6: "", col7: "" }, { name: "", name2: "Original\nNone\nMerged\nPlacement\nDay", col1: "", col2: "", col3: "", col4: "", col5: "", col6: "", col7: "" }, { name: "Jon Lovett", name2: "Jon Lovett", col1: "42", col2: "Los Angeles,California", col3: "Gata", col4: "", col5: "", col6: "1st voted out", col7: "Day 3" }, { name: "TK Foster", name2: "TK Foster", col1: "31", col2: "Upper Marlboro,Maryland", col3: "Tuku", col4: "2nd voted out", col5: "Day 5", col6: "", col7: "" }, { name: "Aysha Welch", name2: "Aysha Welch", col1: "32", col2: "Houston,Texas", col3: "Lavo", col4: "3rd voted out", col5: "Day 7", col6: "", col7: "" }, { name: "Kishan Patel", name2: "Kishan Patel", col1: "28", col2: "San Francisco,California", col3: "4th voted out", col4: "Day 8", col5: "", col6: "", col7: "" }, { name: "Anika Dhar", name2: "Anika Dhar", col1: "26", col2: "Los Angeles,California", col3: "Gata", col4: "5th voted out", col5: "Day 10", col6: "", col7: "" }, { name: "Rome Cooney", name2: "Rome Cooney", col1: "30", col2: "Phoenix,Arizona", col3: "Lavo", col4: "None[a]", col5: "6th voted out", col6: "Day 12", col7: "" }, { name: "Tiyana Hallums", name2: "Tiyana Hallums", col1: "27", col2: "Aiea,Hawaii", col3: "Tuku", col4: "Beka", col5: "7th voted out", col6: "Day 13", col7: "" }, { name: "Sierra Wright", name2: "Sierra Wright", col1: "26", col2: "Phoenixville,Pennsylvania", col3: "Gata", col4: "8th voted out1st jury member", col5: "Day 15", col6: "", col7: "" }, { name: "Sol Yi", name2: "Sol Yi", col1: "43", col2: "Norwalk,Connecticut", col3: "Lavo", col4: "9th voted out2nd jury member", col5: "Day 16", col6: "", col7: "" }, { name: "Gabe Ortis", name2: "Gabe Ortis", col1: "26", col2: "Baltimore,Maryland", col3: "Tuku", col4: "10th voted out3rd jury member", col5: "Day 18", col6: "", col7: "" }, { name: "Kyle Ostwald", name2: "Kyle Ostwald", col1: "31", col2: "Cheboygan,Michigan", col3: "11th voted out4th jury member", col4: "Day 20", col5: "", col6: "", col7: "" }, { name: "Caroline Vidmar", name2: "Caroline Vidmar", col1: "27", col2: "Chicago,Illinois", col3: "12th voted out5th jury member", col4: "Day 22", col5: "", col6: "", col7: "" }, { name: "Andy Rueda", name2: "Andy Rueda", col1: "31", col2: "Brooklyn,New York", col3: "Gata", col4: "13th voted out6th jury member", col5: "Day 23", col6: "", col7: "" }, { name: "Genevieve Mushaluk", name2: "Genevieve Mushaluk", col1: "32", col2: "Winnipeg,Manitoba", col3: "Lavo", col4: "14th voted out7th jury member", col5: "Day 24", col6: "", col7: "" }, { name: "Teeny Chirichillo", name2: "Teeny Chirichillo", col1: "24", col2: "Manahawkin, New Jersey", col3: "Eliminated8th jury member", col4: "Day 25", col5: "", col6: "", col7: "" }, { name: "Sue Smey", name2: "Sue Smey", col1: "59", col2: "Putnam Valley,New York", col3: "Tuku", col4: "2nd runner-up", col5: "Day 26", col6: "", col7: "" }, { name: "Sam Phalen", name2: "Sam Phalen", col1: "24", col2: "Nashville,Tennessee", col3: "Gata", col4: "Runner-up", col5: "", col6: "", col7: "" }, { name: "Rachel LaMont", name2: "Rachel LaMont", col1: "34", col2: "Southfield,Michigan", col3: "Sole Survivor", col4: "", col5: "", col6: "", col7: "" } ]
+            );
+        });
+
+        const antoinettesRawTeamList = [ "Tiyana Hallums", "Kyle Ostwald", "Sierra Wright", "Gabe Ortis", "Caroline Vidmar", "Anika Dhar", "Aysha Welch", "Sue Smey", "Rachel LaMont", "Sol Yi", "Kishan Patel", "Sam Phalen", "Teeny Chirichillo", "TK Foster", "Genevieve Mushaluk", "Andy Rueda", "Rome Cooney", "Jon Lovett" ];
+
+        const antoinettesContestantLeagueData = {
+            name: "Antoinette",
+            userId: "DCC9DCDC-AE5C-4A53-AF09-23F3C957D60B",
+            ranking: antoinettesRawTeamList
+        };
+        const listOfContetantLeagueData = [antoinettesContestantLeagueData]
+
+        const expectedNumberOfRounds = 17;
+
+        // Act
+        const result = await generateContestantRoundScores(testDataFetcher, parseSurvivorEntities, listOfContetantLeagueData);
+
+        // Assert
+        expect(result.rounds.length).toBe(expectedNumberOfRounds);
+
+        // Note: we are always pulling the 0th contestantRoundData because we
+        // are only inserting one contestant into the league
+        // round 0 (only testing to make sure we start is correct)
+        expect(result.rounds[0].round).toBe(0);
+        expect(result.rounds[0].contestantRoundData[0].name).toBe(antoinettesContestantLeagueData.name);
+        expect(result.rounds[0].contestantRoundData[0].roundScore).toBe(170);
+        expect(result.rounds[0].contestantRoundData[0].totalScore).toBe(170);
+
+        //// round 1..13 not testing because we aren't using them today
+
+        // round 11
+        expect(result.rounds[14].round).toBe(14);
+        expect(result.rounds[14].contestantRoundData[0].name).toBe(antoinettesContestantLeagueData.name);
+        expect(result.rounds[14].contestantRoundData[0].roundScore).toBe(0);
+        expect(result.rounds[14].contestantRoundData[0].totalScore).toBe(970);
     });
 });

--- a/__tests__/models/League.js
+++ b/__tests__/models/League.js
@@ -515,4 +515,111 @@ describe("Regression Tests Checking Scoring of Archived Leagues", () => {
         expect(seansRoundScores[14].contestantRoundData[0].roundScore).toBe(0);
         expect(seansRoundScores[14].contestantRoundData[0].totalScore).toBe(730);
     });
+
+    it("Should Score Antoinette correctly for Survivor 47", () => {
+
+        // Arrange
+        const antoinettesRawTeamList = [ { teamName: "Tiyana Hallums", relationship: "needed for ITeam", isParticipating: false, eliminationOrder: 7 }, { teamName: "Kyle Ostwald", relationship: "needed for ITeam", isParticipating: false, eliminationOrder: 11 }, { teamName: "Sierra Wright", relationship: "needed for ITeam", isParticipating: false, eliminationOrder: 8 }, { teamName: "Gabe Ortis", relationship: "needed for ITeam", isParticipating: false, eliminationOrder: 10 }, { teamName: "Caroline Vidmar", relationship: "needed for ITeam", isParticipating: false, eliminationOrder: 12 }, { teamName: "Anika Dhar", relationship: "needed for ITeam", isParticipating: false, eliminationOrder: 5 }, { teamName: "Aysha Welch", relationship: "needed for ITeam", isParticipating: false, eliminationOrder: 3 }, { teamName: "Sue Smey", relationship: "needed for ITeam", isParticipating: false, eliminationOrder: 16 }, { teamName: "Rachel LaMont", relationship: "needed for ITeam", isParticipating: true, eliminationOrder: 1.7976931348623157e+308 }, { teamName: "Sol Yi", relationship: "needed for ITeam", isParticipating: false, eliminationOrder: 9 }, { teamName: "Kishan Patel", relationship: "needed for ITeam", isParticipating: false, eliminationOrder: 4 }, { teamName: "Sam Phalen", relationship: "needed for ITeam", isParticipating: false, eliminationOrder: 17 }, { teamName: "Teeny Chirichillo", relationship: "needed for ITeam", isParticipating: false, eliminationOrder: 15 }, { teamName: "TK Foster", relationship: "needed for ITeam", isParticipating: false, eliminationOrder: 2 }, { teamName: "Genevieve Mushaluk", relationship: "needed for ITeam", isParticipating: false, eliminationOrder: 14 }, { teamName: "Andy Rueda", relationship: "needed for ITeam", isParticipating: false, eliminationOrder: 13 }, { teamName: "Rome Cooney", relationship: "needed for ITeam", isParticipating: false, eliminationOrder: 6 }, { teamName: "Jon Lovett", relationship: "needed for ITeam", isParticipating: false, eliminationOrder: 1 } ];
+
+        const antoinettesParsedAndEmbelishedTeamList = antoinettesRawTeamList.map(t => {
+            return new CompetingEntity(t);
+        });
+
+        const expectedNumberOfRounds = 17;
+        const handicap = 0;
+        const sut = new League(antoinettesParsedAndEmbelishedTeamList);
+
+        // Act
+        const antoinettesRoundScores = sut.generateContestantRoundScores(antoinettesParsedAndEmbelishedTeamList, "testingAntoinette", handicap);
+
+        // Assert
+        expect(antoinettesRoundScores.length).toBe(expectedNumberOfRounds);
+
+        // Note: we are always pulling the 0th contestantRoundData because we
+        // are only inserting on contestant into the league
+        // round 0
+        expect(antoinettesRoundScores[0].round).toBe(0);
+        expect(antoinettesRoundScores[0].contestantRoundData[0].roundScore).toBe(170);
+        expect(antoinettesRoundScores[0].contestantRoundData[0].totalScore).toBe(170);
+
+        // round 1
+        expect(antoinettesRoundScores[1].round).toBe(1);
+        expect(antoinettesRoundScores[1].contestantRoundData[0].roundScore).toBe(150);
+        expect(antoinettesRoundScores[1].contestantRoundData[0].totalScore).toBe(320);
+
+        // round 2
+        expect(antoinettesRoundScores[2].round).toBe(2);
+        expect(antoinettesRoundScores[2].contestantRoundData[0].roundScore).toBe(130);
+        expect(antoinettesRoundScores[2].contestantRoundData[0].totalScore).toBe(450);
+
+        // round 3
+        expect(antoinettesRoundScores[3].round).toBe(3);
+        expect(antoinettesRoundScores[3].contestantRoundData[0].roundScore).toBe(110);
+        expect(antoinettesRoundScores[3].contestantRoundData[0].totalScore).toBe(560);
+
+        // round 4
+        expect(antoinettesRoundScores[4].round).toBe(4);
+        expect(antoinettesRoundScores[4].contestantRoundData[0].roundScore).toBe(100);
+        expect(antoinettesRoundScores[4].contestantRoundData[0].totalScore).toBe(660);
+
+        // round 5
+        expect(antoinettesRoundScores[5].round).toBe(5);
+        expect(antoinettesRoundScores[5].contestantRoundData[0].roundScore).toBe(90);
+        expect(antoinettesRoundScores[5].contestantRoundData[0].totalScore).toBe(750);
+
+        // round 6
+        expect(antoinettesRoundScores[6].round).toBe(6);
+        expect(antoinettesRoundScores[6].contestantRoundData[0].roundScore).toBe(70);
+        expect(antoinettesRoundScores[6].contestantRoundData[0].totalScore).toBe(820);
+
+        // round 7
+        expect(antoinettesRoundScores[7].round).toBe(7);
+        expect(antoinettesRoundScores[7].contestantRoundData[0].roundScore).toBe(60);
+        expect(antoinettesRoundScores[7].contestantRoundData[0].totalScore).toBe(880);
+
+        // round 8
+        expect(antoinettesRoundScores[8].round).toBe(8);
+        expect(antoinettesRoundScores[8].contestantRoundData[0].roundScore).toBe(50);
+        expect(antoinettesRoundScores[8].contestantRoundData[0].totalScore).toBe(930);
+
+        // round 9
+        expect(antoinettesRoundScores[9].round).toBe(9);
+        expect(antoinettesRoundScores[9].contestantRoundData[0].roundScore).toBe(30);
+        expect(antoinettesRoundScores[9].contestantRoundData[0].totalScore).toBe(960);
+
+        // round 10
+        expect(antoinettesRoundScores[10].round).toBe(10);
+        expect(antoinettesRoundScores[10].contestantRoundData[0].roundScore).toBe(10);
+        expect(antoinettesRoundScores[10].contestantRoundData[0].totalScore).toBe(970);
+
+        // round 11
+        expect(antoinettesRoundScores[11].round).toBe(11);
+        expect(antoinettesRoundScores[11].contestantRoundData[0].roundScore).toBe(0);
+        expect(antoinettesRoundScores[11].contestantRoundData[0].totalScore).toBe(970);
+
+        // round 12
+        expect(antoinettesRoundScores[12].round).toBe(12);
+        expect(antoinettesRoundScores[12].contestantRoundData[0].roundScore).toBe(0);
+        expect(antoinettesRoundScores[12].contestantRoundData[0].totalScore).toBe(970);
+
+        // round 13
+        expect(antoinettesRoundScores[13].round).toBe(13);
+        expect(antoinettesRoundScores[13].contestantRoundData[0].roundScore).toBe(0);
+        expect(antoinettesRoundScores[13].contestantRoundData[0].totalScore).toBe(970);
+
+        // round 14
+        expect(antoinettesRoundScores[14].round).toBe(14);
+        expect(antoinettesRoundScores[14].contestantRoundData[0].roundScore).toBe(0);
+        expect(antoinettesRoundScores[14].contestantRoundData[0].totalScore).toBe(970);
+
+        // round 15
+        expect(antoinettesRoundScores[15].round).toBe(15);
+        expect(antoinettesRoundScores[15].contestantRoundData[0].roundScore).toBe(0);
+        expect(antoinettesRoundScores[15].contestantRoundData[0].totalScore).toBe(970);
+
+        // round 16
+        expect(antoinettesRoundScores[16].round).toBe(16);
+        expect(antoinettesRoundScores[16].contestantRoundData[0].roundScore).toBe(0);
+        expect(antoinettesRoundScores[16].contestantRoundData[0].totalScore).toBe(970);
+    });
 });


### PR DESCRIPTION
### Summary/Acceptance Criteria
Exactly as it's name describes. We have started to do this thing where we add a couple of tests which a near or approaching the scope of "App" tests, and are also helpful to catch regressions as we develop the site.

### Screenshots
(N/A this is all backend change)

## Confirm
- [ ] This PR has unit tests scenarios. (N/A just adding new app/regression tests)
- [x] This PR is correctly linked to the relevant issue or milestone.
- [x] This PR has been locally QA'd.
- [ ] This PR has had it's db migrations run. (N/A no new data here)

/assign me
