### PR TITLE
Feature/update node version

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [20.x]
+        node-version: [22.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "prepare": "./node_modules/.bin/husky"
   },
   "engines": {
-    "node": "^20.9.0"
+    "node": "^22.16.0"
   },
   "dependencies": {
     "@types/google.accounts": "^0.0.16",


### PR DESCRIPTION
### Summary/Acceptance Criteria
Am looking to adding a new package and having this upgraded stared being a blocker based on the latest version of the package I am trying to install, so here is a lil fix for that.

### Screenshots
N/A Nothing is different

## Confirm
- [ ] This PR has unit tests scenarios. (N/A no change to functionality)
- [x] This PR is correctly linked to the relevant issue or milestone. 
- [x] This PR has been locally QA'd.
- [ ] This PR has had it's db migrations run. (N/A no data)

## TODO
- [ ] Update Vercel node version so that that will always build w/ latest (22.x)

/assign me
