### PR TITLE
Feature/add crude auth

### DIFF
--- a/__tests__/api/league/route.js
+++ b/__tests__/api/league/route.js
@@ -1,0 +1,12 @@
+import { POST } from "@/app/api/league/route.ts";
+
+describe("POST", () => {
+    it("should return a 401 when auth token is missing", async () => {
+        // Aarrange
+
+        // Act
+        await POST({});
+
+        // Assert
+    });
+});

--- a/__tests__/api/league/route.js
+++ b/__tests__/api/league/route.js
@@ -12,8 +12,10 @@ describe("POST", () => {
         };
 
         // Act
-        await POST(request);
+        const response = await POST(request);
 
         // Assert
+        expect(response).not.toBeNull();
+        expect(response.status).toEqual(401);
     });
 });

--- a/__tests__/api/league/route.js
+++ b/__tests__/api/league/route.js
@@ -7,9 +7,12 @@ import { POST } from "@/app/api/league/route.ts";
 describe("POST", () => {
     it("should return a 401 when auth token is missing", async () => {
         // Aarrange
+        const request = {
+            json: async () => { return {} }
+        };
 
         // Act
-        await POST({});
+        await POST(request);
 
         // Assert
     });

--- a/__tests__/api/league/route.js
+++ b/__tests__/api/league/route.js
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment node
+ */
+
 import { POST } from "@/app/api/league/route.ts";
 
 describe("POST", () => {

--- a/__tests__/api/league/route.js
+++ b/__tests__/api/league/route.js
@@ -18,4 +18,18 @@ describe("POST", () => {
         expect(response).not.toBeNull();
         expect(response.status).toEqual(401);
     });
+
+    it("should return a 401 when auth token is malformed (missing 3 parts)", async () => {
+        // Aarrange
+        const request = {
+            json: async () => { return { token: "someTokenValue" } }
+        };
+
+        // Act
+        const response = await POST(request);
+
+        // Assert
+        expect(response).not.toBeNull();
+        expect(response.status).toEqual(401);
+    });
 });

--- a/__tests__/api/league/route.js
+++ b/__tests__/api/league/route.js
@@ -32,4 +32,18 @@ describe("POST", () => {
         expect(response).not.toBeNull();
         expect(response.status).toEqual(401);
     });
+
+    it("should return a 401 when auth token is malformed (parts are not base64 encoded json)", async () => {
+        // Aarrange
+        const request = {
+            json: async () => { return { token: "someTokenHeader.someTokenBody.someTokenSig" } }
+        };
+
+        // Act
+        const response = await POST(request);
+
+        // Assert
+        expect(response).not.toBeNull();
+        expect(response.status).toEqual(401);
+    });
 });

--- a/__tests__/api/league/route_unit.js
+++ b/__tests__/api/league/route_unit.js
@@ -47,4 +47,21 @@ describe("POST (unit tests)", () => {
         expect(response).not.toBeNull();
         expect(response.status).toEqual(403);
     });
+
+    it("should return allow a post (or  200) when auth token has the exact right userId claim", async () => {
+        // Aarrange
+        testAuthData.sub = "108251633753098119380";
+        const request = {
+            json: async () => { return {
+                token: "testToken"
+            } }
+        };
+
+        // Act
+        const response = await POST(request);
+
+        // Assert
+        expect(response).not.toBeNull();
+        expect(response.status).toEqual(200);
+    });
 });

--- a/__tests__/api/league/route_unit.js
+++ b/__tests__/api/league/route_unit.js
@@ -1,0 +1,50 @@
+/**
+ * @jest-environment node
+ */
+
+jest.mock("google-auth-library");
+import { OAuth2Client } from "google-auth-library";
+import { POST } from "@/app/api/league/route.ts";
+
+const testAuthData = {
+    sub: "123googleTestId",
+    email: "test@test.com",
+    given_name: "TestFirstName",
+    family_name: "TestLastName"
+}
+
+const getPayloadMock = jest.fn().mockImplementation(()=> {
+    return testAuthData
+});
+
+const verifyIdTokenMock = jest.fn().mockImplementation(()=> {
+    return {
+        getPayload: getPayloadMock
+    }
+});
+
+OAuth2Client.mockImplementation(() => {
+    return {
+        verifyIdToken: verifyIdTokenMock
+    }
+});
+
+describe("POST (unit tests)", () => {
+
+    it("should return a 403 when auth token does not have exact right userId claim", async () => {
+        // Aarrange
+
+        const request = {
+            json: async () => { return {
+                token: "testToken"
+            } }
+        };
+
+        // Act
+        const response = await POST(request);
+
+        // Assert
+        expect(response).not.toBeNull();
+        expect(response.status).toEqual(403);
+    });
+});

--- a/app/api/league/route.ts
+++ b/app/api/league/route.ts
@@ -3,6 +3,10 @@ import { OAuth2Client, TokenPayload } from "google-auth-library";
 
 export async function POST(request: NextRequest) {
     // check auth
+    const body = await request.json();
+    if (!body.token) {
+        return NextResponse.json({"error": "you are not authenticated with this service"}, {status: 401})
+    }
 
     // validate/sanitize input
 

--- a/app/api/league/route.ts
+++ b/app/api/league/route.ts
@@ -19,6 +19,7 @@ export async function POST(request: NextRequest) {
         });
     }
     catch(error) {
+        console.log(error);
         return NextResponse.json({"error": unauthenticatedErrorMessage}, {status: 401})
     }
 

--- a/app/api/league/route.ts
+++ b/app/api/league/route.ts
@@ -7,6 +7,13 @@ export async function POST(request: NextRequest) {
     if (!body.token) {
         return NextResponse.json({"error": "you are not authenticated with this service"}, {status: 401})
     }
+    const client = new OAuth2Client();
+    const clientId = process.env.GOOGLE_LOGIN_CLIENT_ID;
+    let authResponse = null;
+    authResponse = await client.verifyIdToken({
+        idToken: body.token,
+        audience: clientId
+    });
 
     // validate/sanitize input
 

--- a/app/api/league/route.ts
+++ b/app/api/league/route.ts
@@ -10,10 +10,14 @@ export async function POST(request: NextRequest) {
     const client = new OAuth2Client();
     const clientId = process.env.GOOGLE_LOGIN_CLIENT_ID;
     let authResponse = null;
-    authResponse = await client.verifyIdToken({
-        idToken: body.token,
-        audience: clientId
-    });
+    try {
+        authResponse = await client.verifyIdToken({
+            idToken: body.token,
+            audience: clientId
+        });
+    }
+    catch(error) {
+    }
 
     // validate/sanitize input
 

--- a/app/api/league/route.ts
+++ b/app/api/league/route.ts
@@ -19,6 +19,7 @@ export async function POST(request: NextRequest) {
         });
     }
     catch(error) {
+        return NextResponse.json({"error": unauthenticatedErrorMessage}, {status: 401})
     }
 
     // validate/sanitize input

--- a/app/api/league/route.ts
+++ b/app/api/league/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { OAuth2Client, TokenPayload } from "google-auth-library";
 
 export async function POST(request: NextRequest) {
     // check auth

--- a/app/api/league/route.ts
+++ b/app/api/league/route.ts
@@ -1,0 +1,12 @@
+import { NextRequest, NextResponse } from "next/server";
+
+export async function POST(request: NextRequest) {
+    // check auth
+
+    // validate/sanitize input
+
+    // insert into db
+
+    // return
+    return NextResponse.json({"message": "posted"});
+}

--- a/app/api/league/route.ts
+++ b/app/api/league/route.ts
@@ -23,6 +23,15 @@ export async function POST(request: NextRequest) {
         return NextResponse.json({"error": unauthenticatedErrorMessage}, {status: 401})
     }
 
+    const payload:TokenPayload | undefined = authResponse.getPayload();
+
+    if(payload){
+        const googleUserId = payload["sub"];
+        if (googleUserId !== "108251633753098119380") {
+            return NextResponse.json({"error": "you are not authorized to perform that action"}, {status: 403});
+        }
+    }
+
     // validate/sanitize input
 
     // insert into db

--- a/app/api/league/route.ts
+++ b/app/api/league/route.ts
@@ -1,11 +1,13 @@
 import { NextRequest, NextResponse } from "next/server";
 import { OAuth2Client, TokenPayload } from "google-auth-library";
 
+const unauthenticatedErrorMessage = "you are not authenticated with this service";
+
 export async function POST(request: NextRequest) {
     // check auth
     const body = await request.json();
     if (!body.token) {
-        return NextResponse.json({"error": "you are not authenticated with this service"}, {status: 401})
+        return NextResponse.json({"error": unauthenticatedErrorMessage}, {status: 401})
     }
     const client = new OAuth2Client();
     const clientId = process.env.GOOGLE_LOGIN_CLIENT_ID;


### PR DESCRIPTION
### Summary/Acceptance Criteria
This is the beginning of a league configuration endpoint where we can post a league configuration. This first step just re-imagines the existing token auth we have the login endpoint. This should be replaced with the session work in #300, but just to keep the posting of league configuration a bit un-blocked, thought I would start with this.

### Screenshot
![Screenshot 2025-07-04 at 6 01 57 PM](https://github.com/user-attachments/assets/86b25972-6353-4938-acf8-53cab7356572)

**_Note: do not do this at home! I was very careful to omit as much of the credential (or "token") as I could and I still triple checked this._**

## Confirm
- [x] This PR has unit tests scenarios. (this came in the form of two sets of tests 1 which use a real `OAuth2Client` and another which mocks it)
- [x] This PR is correctly linked to the relevant issue or milestone.
- [x] This PR has been locally QA'd. (see screenshot which also gets a token from logging in locally)
- [ ] This PR has had it's db migrations run. (N/A no new data here)

/assign me
