### PR TITLE
328 bb 27 leaguecontestant data batch 1

### DIFF
--- a/app/leagueData/BigBrother_27.js
+++ b/app/leagueData/BigBrother_27.js
@@ -14,7 +14,7 @@ const CONTESTANT_LEAGUE_DATA = [
     {
         name: "Sam",
         userId: "CD9F9A71-FF9C-416A-8D0D-C268A13B021F",
-        ranking: []
+        ranking: [ "Katherine Woodman", "Mickey Lee", "Ava Pearl", "Morgan Pope", "Adrian Rocha", "Amy Bingham", "Rylie Jeffries", "Lauren Domingue", "Zach Cornell", "Keanu Soto", "Kelley Jorgensen", "Vince Panaro", "Rachel Reilly", "Cliffton \"Will\" Williams", "Ashley Hollis", "Jimmy Heagerty", "Isaiah \"Zae\" Frederich" ]
     }
 ];
 

--- a/app/leagueData/BigBrother_27.js
+++ b/app/leagueData/BigBrother_27.js
@@ -4,7 +4,7 @@ const CONTESTANT_LEAGUE_DATA = [
     {
         name: "Antoinette",
         userId: "DCC9DCDC-AE5C-4A53-AF09-23F3C957D60B",
-        ranking: []
+        ranking: [ "Adrian Rocha", "Morgan Pope", "Katherine Woodman", "Keanu Soto", "Lauren Domingue", "Mystery Guest", "Rylie Jeffries", "Kelley Jorgensen", "Jimmy Heagerty", "Mickey Lee", "Zach Cornell", "Ava Pearl", "Vince Panaro", "Isaiah \"Zae\" Frederich", "Clifton Williams", "Amy Bingham", "Ashley Hollis" ]
     },
     {
         name: "Jacob",

--- a/app/leagueData/BigBrother_27.js
+++ b/app/leagueData/BigBrother_27.js
@@ -9,7 +9,7 @@ const CONTESTANT_LEAGUE_DATA = [
     {
         name: "Jacob",
         userId: "C7D10281-8879-4F41-929B-723EFBE4A1C4",
-        ranking: []
+        ranking: [ "Katherine Woodman", "Morgan Pope", "Cliffton \"Will\" Williams", "Rachel Reilly", "Ava Pearl", "Lauren Domingue", "Zach Cornell", "Mickey Lee", "Adrian Rocha", "Rylie Jeffries", "Keanu Soto", "Kelley Jorgensen", "Vince Panaro", "Jimmy Heagerty", "Amy Bingham", "Ashley Hollis", "Isaiah \"Zae\" Frederich" ]
     },
     {
         name: "Sam",

--- a/app/leagueData/BigBrother_27.js
+++ b/app/leagueData/BigBrother_27.js
@@ -1,0 +1,21 @@
+
+// Contestant Ranking
+const CONTESTANT_LEAGUE_DATA = [
+    {
+        name: "Antoinette",
+        userId: "DCC9DCDC-AE5C-4A53-AF09-23F3C957D60B",
+        ranking: []
+    },
+    {
+        name: "Jacob",
+        userId: "C7D10281-8879-4F41-929B-723EFBE4A1C4",
+        ranking: []
+    },
+    {
+        name: "Sam",
+        userId: "CD9F9A71-FF9C-416A-8D0D-C268A13B021F",
+        ranking: []
+    }
+];
+
+module.exports = { CONTESTANT_LEAGUE_DATA };

--- a/app/leagueData/BigBrother_27.js
+++ b/app/leagueData/BigBrother_27.js
@@ -4,7 +4,7 @@ const CONTESTANT_LEAGUE_DATA = [
     {
         name: "Antoinette",
         userId: "DCC9DCDC-AE5C-4A53-AF09-23F3C957D60B",
-        ranking: [ "Adrian Rocha", "Morgan Pope", "Katherine Woodman", "Keanu Soto", "Lauren Domingue", "Rachel Reilly", "Rylie Jeffries", "Kelley Jorgensen", "Jimmy Heagerty", "Mickey Lee", "Zach Cornell", "Ava Pearl", "Vince Panaro", "Isaiah \"Zae\" Frederich", "Clifton Williams", "Amy Bingham", "Ashley Hollis" ]
+        ranking: [ "Adrian Rocha", "Morgan Pope", "Katherine Woodman", "Keanu Soto", "Lauren Domingue", "Rachel Reilly", "Rylie Jeffries", "Kelley Jorgensen", "Jimmy Heagerty", "Mickey Lee", "Zach Cornell", "Ava Pearl", "Vince Panaro", "Isaiah \"Zae\" Frederich", "Cliffton \"Will\" Williams", "Amy Bingham", "Ashley Hollis" ]
     },
     {
         name: "Jacob",

--- a/app/leagueData/BigBrother_27.js
+++ b/app/leagueData/BigBrother_27.js
@@ -4,7 +4,7 @@ const CONTESTANT_LEAGUE_DATA = [
     {
         name: "Antoinette",
         userId: "DCC9DCDC-AE5C-4A53-AF09-23F3C957D60B",
-        ranking: [ "Adrian Rocha", "Morgan Pope", "Katherine Woodman", "Keanu Soto", "Lauren Domingue", "Mystery Guest", "Rylie Jeffries", "Kelley Jorgensen", "Jimmy Heagerty", "Mickey Lee", "Zach Cornell", "Ava Pearl", "Vince Panaro", "Isaiah \"Zae\" Frederich", "Clifton Williams", "Amy Bingham", "Ashley Hollis" ]
+        ranking: [ "Adrian Rocha", "Morgan Pope", "Katherine Woodman", "Keanu Soto", "Lauren Domingue", "Rachel Reilly", "Rylie Jeffries", "Kelley Jorgensen", "Jimmy Heagerty", "Mickey Lee", "Zach Cornell", "Ava Pearl", "Vince Panaro", "Isaiah \"Zae\" Frederich", "Clifton Williams", "Amy Bingham", "Ashley Hollis" ]
     },
     {
         name: "Jacob",

--- a/scripts/seedDb.mjs
+++ b/scripts/seedDb.mjs
@@ -2,6 +2,7 @@ import amazingRace35Data from "../app/leagueData/AmazingRace_35.js"
 import amazingRace36Data from "../app/leagueData/AmazingRace_36.js"
 import amazingRace37Data from "../app/leagueData/AmazingRace_37.js"
 import bigBrother26Data from "../app/leagueData/BigBrother_26.js"
+import bigBrother27Data from "../app/leagueData/BigBrother_27.js"
 import survivor47Data from "../app/leagueData/Survivor_47.js"
 import amazingRace35LeagueConfiguration from "../app/leagueConfiguration/AmazingRace_35.js"
 import amazingRace36LeagueConfiguration from "../app/leagueConfiguration/AmazingRace_36.js"
@@ -28,6 +29,7 @@ await recreateLeagueData("amazing_race:35:", amazingRace35Data)
 await recreateLeagueData("amazing_race:36:", amazingRace36Data)
 await recreateLeagueData("amazing_race:37:", amazingRace37Data)
 await recreateLeagueData("big_brother:26:", bigBrother26Data)
+await recreateLeagueData("big_brother:27:", bigBrother27Data)
 await recreateLeagueData("survivor:47:", survivor47Data)
 
 // Delete all league configuration data


### PR DESCRIPTION
### Summary/Acceptance Criteria
This is the first of likely a couple of PRs necessary to add leagueContestant data since this is still checked into source and seeded from there.

### Screenshots
<img width="883" height="406" alt="image" src="https://github.com/user-attachments/assets/9dfa7d92-9c09-4162-b086-667f5e397252" />

## Confirm
- [ ] This PR has unit tests scenarios. (no real tests necessary... but there will be some follow up work since this exposed a few deficiencies)
- [x] This PR is correctly linked to the relevant issue or milestone.
- [x] This PR has been locally QA'd.
- [x] This PR has had it's db migrations run. (Shouldn't need to for prod... since we fixed it for league config, and it is automated)

/assign me
