### PR TITLE
Hotfix/fix survivor 47

### DIFF
--- a/app/leagueData/Survivor_47.js
+++ b/app/leagueData/Survivor_47.js
@@ -4,27 +4,27 @@ const CONTESTANT_LEAGUE_DATA = [
     {
         name: "Antoinette",
         userId: "DCC9DCDC-AE5C-4A53-AF09-23F3C957D60B",
-        ranking: [ "Tiyana Hallums", "Kyle Ostwald", "Sierra Wright", "Gabe Ortis", "Caroline Vidmar", "Anika Dhar", "Aysha Welch", "Sue Smey", "Rachel LaMont", "Sol Yi", "Kishan Patel", "Sam Phalen", "Teeny Chirichillo", "TK Foster", "Genevieve Mushaluk", "Andy Rueda", "Rome Cooney", "Jon Lovett" ]
+        ranking: [ "Tiyana Hallums", "Kyle Ostwald", "Sierra Wright", "Gabe Ortis", "Caroline Vidmar", "Anika Dhar", "Aysha Welch", "Sue Smey", "Rachel LaMont", "Sol Yi", "Kishan Patel", "Sam Phalen", "Teeny Chirichillo", "Terran \"TK\" Foster", "Genevieve Mushaluk", "Andy Rueda", "Rome Cooney", "Jon Lovett" ]
     },
     {
         name: "Cindy",
         userId: "685AAAF4-97DB-4266-A0B7-E61E2C6CA22E",
-        ranking: [ "Rachel LaMont", "TK Foster", "Rome Cooney", "Kyle Ostwald", "Sol Yi", "Aysha Welch", "Caroline Vidmar", "Gabe Ortis", "Genevieve Mushaluk", "Kishan Patel", "Anika Dhar", "Teeny Chirichillo", "Sue Smey", "Sierra Wright", "Sam Phalen", "Tiyana Hallums", "Andy Rueda", "Jon Lovett" ]
+        ranking: [ "Rachel LaMont", "Terran \"TK\" Foster", "Rome Cooney", "Kyle Ostwald", "Sol Yi", "Aysha Welch", "Caroline Vidmar", "Gabe Ortis", "Genevieve Mushaluk", "Kishan Patel", "Anika Dhar", "Teeny Chirichillo", "Sue Smey", "Sierra Wright", "Sam Phalen", "Tiyana Hallums", "Andy Rueda", "Jon Lovett" ]
     },
     {
         name: "Maxon",
         userId: "4BCE61EC-2811-4FB2-81E0-8FD3E8EB3C90",
-        ranking: [ "Rachel LaMont", "Kyle Ostwald", "Teeny Chirichillo", "Sue Smey", "Sierra Wright", "Tiyana Hallums", "Sam Phalen", "Anika Dhar", "Kishan Patel", "Gabe Ortis", "Sol Yi", "Caroline Vidmar", "Genevieve Mushaluk", "Andy Rueda", "Rome Cooney", "TK Foster", "Aysha Welch", "Jon Lovett" ]
+        ranking: [ "Rachel LaMont", "Kyle Ostwald", "Teeny Chirichillo", "Sue Smey", "Sierra Wright", "Tiyana Hallums", "Sam Phalen", "Anika Dhar", "Kishan Patel", "Gabe Ortis", "Sol Yi", "Caroline Vidmar", "Genevieve Mushaluk", "Andy Rueda", "Rome Cooney", "Terran \"TK\" Foster", "Aysha Welch", "Jon Lovett" ]
     },
     {
         name: "Jacob",
         userId: "C7D10281-8879-4F41-929B-723EFBE4A1C4",
-        ranking: [ "Gabe Ortis", "TK Foster", "Anika Dhar", "Aysha Welch", "Sue Smey", "Sierra Wright", "Caroline Vidmar", "Rachel LaMont", "Teeny Chirichillo", "Rome Cooney", "Tiyana Hallums", "Kyle Ostwald", "Kishan Patel", "Genevieve Mushaluk", "Sol Yi", "Sam Phalen", "Andy Rueda", "Jon Lovett" ]
+        ranking: [ "Gabe Ortis", "Terran \"TK\" Foster", "Anika Dhar", "Aysha Welch", "Sue Smey", "Sierra Wright", "Caroline Vidmar", "Rachel LaMont", "Teeny Chirichillo", "Rome Cooney", "Tiyana Hallums", "Kyle Ostwald", "Kishan Patel", "Genevieve Mushaluk", "Sol Yi", "Sam Phalen", "Andy Rueda", "Jon Lovett" ]
     },
     {
         name: "Sam",
         userId: "CD9F9A71-FF9C-416A-8D0D-C268A13B021F",
-        ranking: [ "Rachel LaMont", "Genevieve Mushaluk", "Aysha Welch", "Sierra Wright", "Sam Phalen", "TK Foster", "Teeny Chirichillo", "Kishan Patel", "Kyle Ostwald", "Sol Yi", "Gabe Ortis", "Caroline Vidmar", "Tiyana Hallums", "Sue Smey", "Anika Dhar", "Andy Rueda", "Rome Cooney", "Jon Lovett" ]
+        ranking: [ "Rachel LaMont", "Genevieve Mushaluk", "Aysha Welch", "Sierra Wright", "Sam Phalen", "Terran \"TK\" Foster", "Teeny Chirichillo", "Kishan Patel", "Kyle Ostwald", "Sol Yi", "Gabe Ortis", "Caroline Vidmar", "Tiyana Hallums", "Sue Smey", "Anika Dhar", "Andy Rueda", "Rome Cooney", "Jon Lovett" ]
     }
 ];
 


### PR DESCRIPTION
### Summary/Acceptance Criteria
Our biggest ally Wikipedia, changed it's format again and broke our site 😛 

### Screenshots
(N/A... it's fixed)
What it was doing:
<img width="754" height="244" alt="image" src="https://github.com/user-attachments/assets/90a2406f-339b-451f-a5f4-2a02fd8a9148" />
... Now it works 😛 

## Confirm
- [ ] This PR has unit tests scenarios. (Also not sure what testing is right here, Wikipedia change it's data again 🙄)
- [ ] This PR is correctly linked to the relevant issue or milestone. (Not sure what, if any, milestone this should go in)
- [x] This PR has been locally QA'd.
- [x] This PR has had it's db migrations run. (no need to run in prod we have a github action)

/assign me
