### PR TITLE
312 save league config to database in the api

### DIFF
--- a/__tests__/api/league/route.js
+++ b/__tests__/api/league/route.js
@@ -416,5 +416,6 @@ describe("POST (unit tests)", () => {
         expect(response.status).toEqual(200);
         expect(request.json).toHaveBeenCalledTimes(1);
         expect(writeLeagueConfigurationData).toHaveBeenCalledTimes(1);
+        expect(writeLeagueConfigurationData).toHaveBeenCalledWith(`league_configuration:${happyPathRequest.leagueStatus}:${happyPathRequest.leagueKey}`, expect.anything());
     })
 });

--- a/__tests__/api/league/route.js
+++ b/__tests__/api/league/route.js
@@ -558,4 +558,27 @@ describe("POST (unit tests)", () => {
                 "preGoogleSheetsLinkText": expect.anything(),
             }));
     });
+
+    it("should call writeLeagueConfigurationData with a config with a postGoogleSheetsLinkText", async () => {
+        // Arrange
+        const request = {
+            json: jest.fn().mockImplementation(async () => {
+                return happyPathRequest
+            })
+        };
+
+        // Act
+        const response = await POST(request);
+
+        // Assert
+        expect(response).not.toBeNull();
+        expect(response.status).toEqual(200);
+        expect(request.json).toHaveBeenCalledTimes(1);
+        expect(writeLeagueConfigurationData).toHaveBeenCalledTimes(1);
+        expect(writeLeagueConfigurationData).toHaveBeenCalledWith(
+            expect.anything(),
+            expect.objectContaining({
+                "postGoogleSheetsLinkText": expect.anything(),
+            }));
+    });
 });

--- a/__tests__/api/league/route.js
+++ b/__tests__/api/league/route.js
@@ -489,4 +489,27 @@ describe("POST (unit tests)", () => {
                 "googleSheetUrl": happyPathRequest.googleSheetUrl,
             }));
     });
+
+    it("should call writeLeagueConfigurationData with a config with a leageStatus", async () => {
+        // Arrange
+        const request = {
+            json: jest.fn().mockImplementation(async () => {
+                return happyPathRequest
+            })
+        };
+
+        // Act
+        const response = await POST(request);
+
+        // Assert
+        expect(response).not.toBeNull();
+        expect(response.status).toEqual(200);
+        expect(request.json).toHaveBeenCalledTimes(1);
+        expect(writeLeagueConfigurationData).toHaveBeenCalledTimes(1);
+        expect(writeLeagueConfigurationData).toHaveBeenCalledWith(
+            expect.anything(),
+            expect.objectContaining({
+                "leagueStatus": happyPathRequest.leagueStatus,
+            }));
+    });
 });

--- a/__tests__/api/league/route.js
+++ b/__tests__/api/league/route.js
@@ -395,4 +395,21 @@ describe("POST (unit tests)", () => {
         const bodyString = new TextDecoder().decode(rawBody.value)
         expect(bodyString).toContain("leagueKey");
     });
+
+    it("should call writeLeagueConfigurationData with expected key", async () => {
+        // Arrange
+        const request = {
+            json: jest.fn().mockImplementation(async () => {
+                return happyPathRequest
+            })
+        };
+
+        // Act
+        const response = await POST(request);
+
+        // Assert
+        expect(response).not.toBeNull();
+        expect(response.status).toEqual(200);
+        expect(request.json).toHaveBeenCalledTimes(1);
+    })
 });

--- a/__tests__/api/league/route.js
+++ b/__tests__/api/league/route.js
@@ -604,4 +604,27 @@ describe("POST (unit tests)", () => {
                 "competitingEntityName": happyPathRequest.contestantType,
             }));
     });
+
+    it("should call writeLeagueConfigurationData with a config with a contestantLeagueDataKeyPrefix", async () => {
+        // Arrange
+        const request = {
+            json: jest.fn().mockImplementation(async () => {
+                return happyPathRequest
+            })
+        };
+
+        // Act
+        const response = await POST(request);
+
+        // Assert
+        expect(response).not.toBeNull();
+        expect(response.status).toEqual(200);
+        expect(request.json).toHaveBeenCalledTimes(1);
+        expect(writeLeagueConfigurationData).toHaveBeenCalledTimes(1);
+        expect(writeLeagueConfigurationData).toHaveBeenCalledWith(
+            expect.anything(),
+            expect.objectContaining({
+                "contestantLeagueDataKeyPrefix": `${happyPathRequest.leagueKey}:*`
+            }));
+    });
 });

--- a/__tests__/api/league/route.js
+++ b/__tests__/api/league/route.js
@@ -535,4 +535,27 @@ describe("POST (unit tests)", () => {
                 "castPhrase": happyPathRequest.wikiSectionHeader,
             }));
     });
+
+    it("should call writeLeagueConfigurationData with a config with a preGoogleSheetsLinkText", async () => {
+        // Arrange
+        const request = {
+            json: jest.fn().mockImplementation(async () => {
+                return happyPathRequest
+            })
+        };
+
+        // Act
+        const response = await POST(request);
+
+        // Assert
+        expect(response).not.toBeNull();
+        expect(response.status).toEqual(200);
+        expect(request.json).toHaveBeenCalledTimes(1);
+        expect(writeLeagueConfigurationData).toHaveBeenCalledTimes(1);
+        expect(writeLeagueConfigurationData).toHaveBeenCalledWith(
+            expect.anything(),
+            expect.objectContaining({
+                "preGoogleSheetsLinkText": expect.anything(),
+            }));
+    });
 });

--- a/__tests__/api/league/route.js
+++ b/__tests__/api/league/route.js
@@ -416,6 +416,8 @@ describe("POST (unit tests)", () => {
         expect(response.status).toEqual(200);
         expect(request.json).toHaveBeenCalledTimes(1);
         expect(writeLeagueConfigurationData).toHaveBeenCalledTimes(1);
-        expect(writeLeagueConfigurationData).toHaveBeenCalledWith(`league_configuration:${happyPathRequest.leagueStatus}:${happyPathRequest.leagueKey}`, expect.anything());
+        expect(writeLeagueConfigurationData).toHaveBeenCalledWith(
+            `league_configuration:${happyPathRequest.leagueStatus}:${happyPathRequest.leagueKey}`,
+            expect.anything());
     })
 });

--- a/__tests__/api/league/route.js
+++ b/__tests__/api/league/route.js
@@ -420,4 +420,27 @@ describe("POST (unit tests)", () => {
             `league_configuration:${happyPathRequest.leagueStatus}:${happyPathRequest.leagueKey}`,
             expect.anything());
     })
+
+    it("should call writeLeagueConfigurationData with a config with a wikiPageUrl", async () => {
+        // Arrange
+        const request = {
+            json: jest.fn().mockImplementation(async () => {
+                return happyPathRequest
+            })
+        };
+
+        // Act
+        const response = await POST(request);
+
+        // Assert
+        expect(response).not.toBeNull();
+        expect(response.status).toEqual(200);
+        expect(request.json).toHaveBeenCalledTimes(1);
+        expect(writeLeagueConfigurationData).toHaveBeenCalledTimes(1);
+        expect(writeLeagueConfigurationData).toHaveBeenCalledWith(
+            expect.anything(),
+            expect.objectContaining({
+                "wikiPageUrl": `https://en.wikipedia.org/wiki/${happyPathRequest.wikiPageName}`
+            }));
+    });
 });

--- a/__tests__/api/league/route.js
+++ b/__tests__/api/league/route.js
@@ -581,4 +581,27 @@ describe("POST (unit tests)", () => {
                 "postGoogleSheetsLinkText": expect.anything(),
             }));
     });
+
+    it("should call writeLeagueConfigurationData with a config with a competingEntityName", async () => {
+        // Arrange
+        const request = {
+            json: jest.fn().mockImplementation(async () => {
+                return happyPathRequest
+            })
+        };
+
+        // Act
+        const response = await POST(request);
+
+        // Assert
+        expect(response).not.toBeNull();
+        expect(response.status).toEqual(200);
+        expect(request.json).toHaveBeenCalledTimes(1);
+        expect(writeLeagueConfigurationData).toHaveBeenCalledTimes(1);
+        expect(writeLeagueConfigurationData).toHaveBeenCalledWith(
+            expect.anything(),
+            expect.objectContaining({
+                "competitingEntityName": happyPathRequest.contestantType,
+            }));
+    });
 });

--- a/__tests__/api/league/route.js
+++ b/__tests__/api/league/route.js
@@ -512,4 +512,27 @@ describe("POST (unit tests)", () => {
                 "leagueStatus": happyPathRequest.leagueStatus,
             }));
     });
+
+    it("should call writeLeagueConfigurationData with a config with a castPhrase", async () => {
+        // Arrange
+        const request = {
+            json: jest.fn().mockImplementation(async () => {
+                return happyPathRequest
+            })
+        };
+
+        // Act
+        const response = await POST(request);
+
+        // Assert
+        expect(response).not.toBeNull();
+        expect(response.status).toEqual(200);
+        expect(request.json).toHaveBeenCalledTimes(1);
+        expect(writeLeagueConfigurationData).toHaveBeenCalledTimes(1);
+        expect(writeLeagueConfigurationData).toHaveBeenCalledWith(
+            expect.anything(),
+            expect.objectContaining({
+                "castPhrase": happyPathRequest.wikiSectionHeader,
+            }));
+    });
 });

--- a/__tests__/api/league/route.js
+++ b/__tests__/api/league/route.js
@@ -443,4 +443,27 @@ describe("POST (unit tests)", () => {
                 "wikiPageUrl": `https://en.wikipedia.org/wiki/${happyPathRequest.wikiPageName}`
             }));
     });
+
+    it("should call writeLeagueConfigurationData with a config with a wikiApiUrl", async () => {
+        // Arrange
+        const request = {
+            json: jest.fn().mockImplementation(async () => {
+                return happyPathRequest
+            })
+        };
+
+        // Act
+        const response = await POST(request);
+
+        // Assert
+        expect(response).not.toBeNull();
+        expect(response.status).toEqual(200);
+        expect(request.json).toHaveBeenCalledTimes(1);
+        expect(writeLeagueConfigurationData).toHaveBeenCalledTimes(1);
+        expect(writeLeagueConfigurationData).toHaveBeenCalledWith(
+            expect.anything(),
+            expect.objectContaining({
+                "wikiApiUrl": `https://en.wikipedia.org/w/api.php?action=parse&format=json&page=${happyPathRequest.wikiPageName}`,
+            }));
+    });
 });

--- a/__tests__/api/league/route.js
+++ b/__tests__/api/league/route.js
@@ -50,6 +50,10 @@ beforeEach(() => {
     };
 });
 
+afterEach(() => {
+    jest.clearAllMocks();
+});
+
 describe("POST (unit tests)", () => {
     it("should return a 403 when auth token does not have exact right userId claim", async () => {
         // Arrange

--- a/__tests__/api/league/route.js
+++ b/__tests__/api/league/route.js
@@ -3,7 +3,9 @@
  */
 
 jest.mock("google-auth-library");
+jest.mock("../../../app/dataSources/dbFetch");
 import { OAuth2Client } from "google-auth-library";
+import { writeLeagueConfigurationData } from "@/app/dataSources/dbFetch";
 import { POST } from "@/app/api/league/route.ts";
 
 let testAuthData = {}
@@ -23,6 +25,10 @@ OAuth2Client.mockImplementation(() => {
     return {
         verifyIdToken: verifyIdTokenMock
     }
+});
+
+writeLeagueConfigurationData.mockImplementation(() => {
+    return () => { }
 });
 
 beforeEach(() => {

--- a/__tests__/api/league/route.js
+++ b/__tests__/api/league/route.js
@@ -466,4 +466,27 @@ describe("POST (unit tests)", () => {
                 "wikiApiUrl": `https://en.wikipedia.org/w/api.php?action=parse&format=json&page=${happyPathRequest.wikiPageName}`,
             }));
     });
+
+    it("should call writeLeagueConfigurationData with a config with a googleSheetUrl", async () => {
+        // Arrange
+        const request = {
+            json: jest.fn().mockImplementation(async () => {
+                return happyPathRequest
+            })
+        };
+
+        // Act
+        const response = await POST(request);
+
+        // Assert
+        expect(response).not.toBeNull();
+        expect(response.status).toEqual(200);
+        expect(request.json).toHaveBeenCalledTimes(1);
+        expect(writeLeagueConfigurationData).toHaveBeenCalledTimes(1);
+        expect(writeLeagueConfigurationData).toHaveBeenCalledWith(
+            expect.anything(),
+            expect.objectContaining({
+                "googleSheetUrl": happyPathRequest.googleSheetUrl,
+            }));
+    });
 });

--- a/__tests__/api/league/route.js
+++ b/__tests__/api/league/route.js
@@ -411,5 +411,6 @@ describe("POST (unit tests)", () => {
         expect(response).not.toBeNull();
         expect(response.status).toEqual(200);
         expect(request.json).toHaveBeenCalledTimes(1);
+        expect(writeLeagueConfigurationData).toHaveBeenCalledTimes(1);
     })
 });

--- a/app/api/league/route.ts
+++ b/app/api/league/route.ts
@@ -65,6 +65,7 @@ export async function POST(request: NextRequest) {
     const leagueConfigKey = `league_configuration:${body.leagueStatus}:${body.leagueKey}`;
     const leagueConfig = {
         wikiPageUrl: `https://en.wikipedia.org/wiki/${body.wikiPageName}`,
+        wikiApiUrl: `https://en.wikipedia.org/w/api.php?action=parse&format=json&page=${body.wikiPageName}`,
     };
 
     await writeLeagueConfigurationData(leagueConfigKey, leagueConfig);

--- a/app/api/league/route.ts
+++ b/app/api/league/route.ts
@@ -62,6 +62,10 @@ export async function POST(request: NextRequest) {
     }
 
     // insert into db
+    const leagueConfigKey = "";
+    const leagueConfig = {};
+
+    await writeLeagueConfigurationData(leagueConfigKey, leagueConfig);
 
     // return
     return NextResponse.json({"message": "posted"});

--- a/app/api/league/route.ts
+++ b/app/api/league/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { OAuth2Client, TokenPayload } from "google-auth-library";
 import * as z from "zod/v4";
+import { writeLeagueConfigurationData } from "@/app/dataSources/dbFetch";
 
 const unauthenticatedErrorMessage = "you are not authenticated with this service";
 const validLeagueStatuses = ["active","archive"];

--- a/app/api/league/route.ts
+++ b/app/api/league/route.ts
@@ -68,6 +68,7 @@ export async function POST(request: NextRequest) {
         wikiApiUrl: `https://en.wikipedia.org/w/api.php?action=parse&format=json&page=${body.wikiPageName}`,
         googleSheetUrl: body.googleSheetUrl,
         leagueStatus: body.leagueStatus,
+        castPhrase: body.wikiSectionHeader,
     };
 
     await writeLeagueConfigurationData(leagueConfigKey, leagueConfig);

--- a/app/api/league/route.ts
+++ b/app/api/league/route.ts
@@ -63,7 +63,9 @@ export async function POST(request: NextRequest) {
 
     // insert into db
     const leagueConfigKey = `league_configuration:${body.leagueStatus}:${body.leagueKey}`;
-    const leagueConfig = {};
+    const leagueConfig = {
+        wikiPageUrl: `https://en.wikipedia.org/wiki/${body.wikiPageName}`,
+    };
 
     await writeLeagueConfigurationData(leagueConfigKey, leagueConfig);
 

--- a/app/api/league/route.ts
+++ b/app/api/league/route.ts
@@ -72,6 +72,7 @@ export async function POST(request: NextRequest) {
         preGoogleSheetsLinkText: "This season's contestant data has been sourced from",
         postGoogleSheetsLinkText: "which was populated using a google form.",
         competitingEntityName: body.contestantType,
+        contestantLeagueDataKeyPrefix: `${body.leagueKey}:*`
     };
 
     await writeLeagueConfigurationData(leagueConfigKey, leagueConfig);

--- a/app/api/league/route.ts
+++ b/app/api/league/route.ts
@@ -71,6 +71,7 @@ export async function POST(request: NextRequest) {
         castPhrase: body.wikiSectionHeader,
         preGoogleSheetsLinkText: "This season's contestant data has been sourced from",
         postGoogleSheetsLinkText: "which was populated using a google form.",
+        competitingEntityName: body.contestantType,
     };
 
     await writeLeagueConfigurationData(leagueConfigKey, leagueConfig);

--- a/app/api/league/route.ts
+++ b/app/api/league/route.ts
@@ -66,6 +66,7 @@ export async function POST(request: NextRequest) {
     const leagueConfig = {
         wikiPageUrl: `https://en.wikipedia.org/wiki/${body.wikiPageName}`,
         wikiApiUrl: `https://en.wikipedia.org/w/api.php?action=parse&format=json&page=${body.wikiPageName}`,
+        googleSheetUrl: body.googleSheetUrl,
     };
 
     await writeLeagueConfigurationData(leagueConfigKey, leagueConfig);

--- a/app/api/league/route.ts
+++ b/app/api/league/route.ts
@@ -69,6 +69,8 @@ export async function POST(request: NextRequest) {
         googleSheetUrl: body.googleSheetUrl,
         leagueStatus: body.leagueStatus,
         castPhrase: body.wikiSectionHeader,
+        preGoogleSheetsLinkText: "This season's contestant data has been sourced from",
+        postGoogleSheetsLinkText: "which was populated using a google form.",
     };
 
     await writeLeagueConfigurationData(leagueConfigKey, leagueConfig);

--- a/app/api/league/route.ts
+++ b/app/api/league/route.ts
@@ -67,6 +67,7 @@ export async function POST(request: NextRequest) {
         wikiPageUrl: `https://en.wikipedia.org/wiki/${body.wikiPageName}`,
         wikiApiUrl: `https://en.wikipedia.org/w/api.php?action=parse&format=json&page=${body.wikiPageName}`,
         googleSheetUrl: body.googleSheetUrl,
+        leagueStatus: body.leagueStatus,
     };
 
     await writeLeagueConfigurationData(leagueConfigKey, leagueConfig);

--- a/app/api/league/route.ts
+++ b/app/api/league/route.ts
@@ -62,7 +62,7 @@ export async function POST(request: NextRequest) {
     }
 
     // insert into db
-    const leagueConfigKey = "";
+    const leagueConfigKey = `league_configuration:${body.leagueStatus}:${body.leagueKey}`;
     const leagueConfig = {};
 
     await writeLeagueConfigurationData(leagueConfigKey, leagueConfig);

--- a/app/dataSources/dbFetch.tsx
+++ b/app/dataSources/dbFetch.tsx
@@ -76,7 +76,7 @@ export async function getLeagueConfigurationKeys(): Promise<string[]> {
     }
 }
 
-export async function writeLeagueConfigurationData(leagueConfigurationKey: string, leagueConfiguration: ILeagueConfiguration): void {
+export async function writeLeagueConfigurationData(leagueConfigurationKey: string, leagueConfiguration: ILeagueConfigurationData): Promise<void> {
 
     if (leagueConfigurationKey === undefined) {
         throw new Error("Unable to writeLeagueConfigurationData. Provided param 'leagueConfigurationKey' is undefined but must have a value\"");

--- a/app/dataSources/dbFetch.tsx
+++ b/app/dataSources/dbFetch.tsx
@@ -76,6 +76,25 @@ export async function getLeagueConfigurationKeys(): Promise<string[]> {
     }
 }
 
+export async function writeLeagueConfigurationData(leagueConfigurationKey: string, leagueConfiguration: ILeagueConfiguration): void {
+
+    if (leagueConfigurationKey === undefined) {
+        throw new Error("Unable to writeLeagueConfigurationData. Provided param 'leagueConfigurationKey' is undefined but must have a value\"");
+    };
+    if (leagueConfiguration === undefined) {
+        throw new Error("Unable to writeLeagueConfigurationData. Provided param 'leagueConfiguration' is undefined but must have a value\"");
+    };
+
+    const redis = new Redis({
+        url: process.env.KV_REST_API_URL,
+        token: process.env.KV_REST_API_TOKEN
+    });
+
+    const leagueConfigString = JSON.stringify(leagueConfiguration)
+
+    await redis.json.set(leagueConfigurationKey, "$", leagueConfigString)
+}
+
 export async function getLeagueConfigurationData(leagueConfigurationKey: string): Promise<ILeagueConfigurationData> {
 
     if (leagueConfigurationKey === undefined) {
@@ -106,3 +125,4 @@ export async function writeGoogleUserData (googleUserId: string){
     const leagueConfigString = JSON.stringify(userDbObj)
     await redis.json.set(`user:${googleUserId}`, "$", leagueConfigString)
 }
+


### PR DESCRIPTION
### Summary/Acceptance Criteria
Exactly as it's name describes. This ends up being a logical extension to #301 because some of these are updated to be in the same shape that we currently expect a league configuration.

### Screenshots
(N/A) deep backend change... just showing the result of this change
Starting:
<img width="861" height="491" alt="image" src="https://github.com/user-attachments/assets/98f7377d-3aad-40e3-8167-47aa610770c2" />


Action:
<img width="712" height="336" alt="Screenshot 2025-07-20 at 7 16 30 PM" src="https://github.com/user-attachments/assets/76521815-4cc0-483a-a3d8-6774f48eeaf8" />


Result:
<img width="905" height="593" alt="image" src="https://github.com/user-attachments/assets/3f397432-06c6-48f1-b5c0-deddee34b23d" />


## Confirm
- [x] This PR has unit tests scenarios.
- [x] This PR is correctly linked to the relevant issue or milestone.
- [x] This PR has been locally QA'd. (see screenshots)
- [ ] This PR has had it's db migrations run. (N/A there is no new data here)

/assign me
