### PR TITLE
338 logout back end

### DIFF
--- a/__tests__/api/logout/route.js
+++ b/__tests__/api/logout/route.js
@@ -1,10 +1,24 @@
 /**
  * @jest-environment node
  */
+import { POST } from "@/app/api/logout/route.ts";
 
 describe("POST", () => {
     it("should be able to get a session cookie from header", async () => {
-        
+
+        // Arrange
+        const requestMock = {
+            url: "http://localhost:3000/api/logout",
+            cookies: {
+                get: () => "a session cookie"
+            }
+        };
+
+        // Act
+        const LogoutResponse = await POST(requestMock);
+
+        // Assert
+        expect(LogoutResponse).not.toBeNull();
     });
 
 });

--- a/__tests__/api/logout/route.js
+++ b/__tests__/api/logout/route.js
@@ -39,4 +39,23 @@ describe("POST", () => {
         expect(LogoutResponse.status).not.toBeNull();
         expect(LogoutResponse.status.toString()).toMatch(/^3/);
     });
+
+    it("should return with a location header set", async () => {
+
+        // Arrange
+        const requestMock = {
+            url: "http://localhost:3000/api/logout",
+            cookies: {
+                get: () => "a session cookie"
+            }
+        };
+
+        // Act
+        const LogoutResponse = await POST(requestMock);
+
+        // Assert
+        expect(LogoutResponse).not.toBeNull();
+        expect(LogoutResponse.headers).not.toBeNull();
+        expect(LogoutResponse.headers.get("location")).not.toBeNull();
+    });
 });

--- a/__tests__/api/logout/route.js
+++ b/__tests__/api/logout/route.js
@@ -1,0 +1,10 @@
+/**
+ * @jest-environment node
+ */
+
+describe("POST", () => {
+    it("should be able to get a session cookie from header", async () => {
+        
+    });
+
+});

--- a/__tests__/api/logout/route.js
+++ b/__tests__/api/logout/route.js
@@ -58,4 +58,25 @@ describe("POST", () => {
         expect(LogoutResponse.headers).not.toBeNull();
         expect(LogoutResponse.headers.get("location")).not.toBeNull();
     });
+
+    it("should return a set-cookie header for a session cookie with max-age: 0", async () => {
+
+        // Arrange
+        const requestMock = {
+            url: "http://localhost:3000/api/logout",
+            cookies: {
+                get: () => "a session cookie"
+            }
+        };
+
+        // Act
+        const LogoutResponse = await POST(requestMock);
+
+        // Assert
+        expect(LogoutResponse).not.toBeNull();
+        expect(LogoutResponse.cookies).not.toBeNull();
+        expect(LogoutResponse.cookies.get("session")).not.toBeUndefined();
+        expect(LogoutResponse.cookies.get("session").maxAge).not.toBeUndefined();
+        expect(LogoutResponse.cookies.get("session").maxAge).toBe(0);
+    });
 });

--- a/__tests__/api/logout/route.js
+++ b/__tests__/api/logout/route.js
@@ -21,4 +21,22 @@ describe("POST", () => {
         expect(LogoutResponse).not.toBeNull();
     });
 
+    it("should return a redirect", async () => {
+
+        // Arrange
+        const requestMock = {
+            url: "http://localhost:3000/api/logout",
+            cookies: {
+                get: () => "a session cookie"
+            }
+        };
+
+        // Act
+        const LogoutResponse = await POST(requestMock);
+
+        // Assert
+        expect(LogoutResponse).not.toBeNull();
+        expect(LogoutResponse.status).not.toBeNull();
+        expect(LogoutResponse.status.toString()).toMatch(/^3/);
+    });
 });

--- a/__tests__/api/logout/route.js
+++ b/__tests__/api/logout/route.js
@@ -37,26 +37,7 @@ describe("POST", () => {
         // Assert
         expect(LogoutResponse).not.toBeNull();
         expect(LogoutResponse.status).not.toBeNull();
-        expect(LogoutResponse.status.toString()).toMatch(/^3/);
-    });
-
-    it("should return with a location header set", async () => {
-
-        // Arrange
-        const requestMock = {
-            url: "http://localhost:3000/api/logout",
-            cookies: {
-                get: () => "a session cookie"
-            }
-        };
-
-        // Act
-        const LogoutResponse = await POST(requestMock);
-
-        // Assert
-        expect(LogoutResponse).not.toBeNull();
-        expect(LogoutResponse.headers).not.toBeNull();
-        expect(LogoutResponse.headers.get("location")).not.toBeNull();
+        expect(LogoutResponse.status.toString()).toMatch(/^2/);
     });
 
     it("should return a set-cookie header for a session cookie with max-age: 0", async () => {

--- a/__tests__/api/session/session.js
+++ b/__tests__/api/session/session.js
@@ -1,5 +1,12 @@
 import { removeSession } from "@/app/api/session/session.tsx";
 
+beforeEach(() => {
+    global.conosle = {
+        log: jest.fn(),
+        warn: jest.fn(),
+    };
+});
+
 describe("removeSession", () => {
     it("Should call set on the response on happy path", async () => {
 
@@ -21,5 +28,27 @@ describe("removeSession", () => {
 
         // Assert
         expect(responseMock.cookies.set).toBeCalled();
+    });
+
+    it("Should log a warning when sessionCookie is not found", async () => {
+
+        // Arrange
+        const requestMock = {
+            cookies: {
+                get: () => undefined
+            }
+        };
+
+        const responseMock = {
+            cookies: {
+                set: jest.fn()
+            }
+        };
+
+        // Act
+        await removeSession(requestMock, responseMock);
+
+        // Assert
+        expect(console.warn).toHaveBeenCalled();
     });
 });

--- a/__tests__/api/session/session.js
+++ b/__tests__/api/session/session.js
@@ -1,0 +1,25 @@
+import { removeSession } from "@/app/api/session/session.tsx";
+
+describe("removeSession", () => {
+    it("Should call set on the response on happy path", async () => {
+
+        // Arrange
+        const requestMock = {
+            cookies: {
+                get: () => "a session cookie"
+            }
+        };
+
+        const responseMock = {
+            cookies: {
+                set: jest.fn()
+            }
+        };
+
+        // Act
+        await removeSession(requestMock, responseMock);
+
+        // Assert
+        expect(responseMock.cookies.set).toBeCalled();
+    });
+});

--- a/__tests__/api/session/session.js
+++ b/__tests__/api/session/session.js
@@ -3,7 +3,7 @@ import { removeSession } from "@/app/api/session/session.tsx";
 beforeEach(() => {
     global.conosle = {
         log: jest.fn(),
-        warn: jest.fn(),
+        warn: jest.spyOn(console, "warn").mockImplementation(() => {}),
     };
 });
 

--- a/app/api/logout/route.ts
+++ b/app/api/logout/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 
 export async function POST(request: NextRequest) {
-    const response = NextResponse.json({}, {status: 200});
+    const response = NextResponse.json({}, {status: 302});
 
     return response;
 }

--- a/app/api/logout/route.ts
+++ b/app/api/logout/route.ts
@@ -2,8 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { removeSession } from "../session/session";
 
 export async function POST(request: NextRequest) {
-    const newUrl = new URL("/", request.url)
-    const response = NextResponse.redirect(newUrl, 302);
+    const response = new NextResponse(null, {status: 205});
     removeSession(request, response);
 
     return response;

--- a/app/api/logout/route.ts
+++ b/app/api/logout/route.ts
@@ -1,8 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
+import { removeSession } from "../session/session";
 
 export async function POST(request: NextRequest) {
     const newUrl = new URL("/", request.url)
     const response = NextResponse.redirect(newUrl, 302);
+    removeSession(request, response);
 
     return response;
 }

--- a/app/api/logout/route.ts
+++ b/app/api/logout/route.ts
@@ -1,7 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
 
 export async function POST(request: NextRequest) {
-    const response = NextResponse.json({}, {status: 302});
+    const newUrl = new URL("/", request.url)
+    const response = NextResponse.redirect(newUrl, 302);
 
     return response;
 }

--- a/app/api/logout/route.ts
+++ b/app/api/logout/route.ts
@@ -1,0 +1,7 @@
+import { NextRequest, NextResponse } from "next/server";
+
+export async function POST(request: NextRequest) {
+    const response = NextResponse.json({}, {status: 200});
+
+    return response;
+}

--- a/app/api/session/session.tsx
+++ b/app/api/session/session.tsx
@@ -52,6 +52,7 @@ export async function removeSession(request: NextRequest, response: NextResponse
     const sessionCookie = request.cookies.get(sessionCookieName);
     if (sessionCookie === undefined) {
         console.warn("Client tried to logout without an existing sessionCookie in the logout request");
+        return;
     }
     response.cookies.set(sessionCookieName, sessionCookie, {
         httpOnly: true,

--- a/app/api/session/session.tsx
+++ b/app/api/session/session.tsx
@@ -54,7 +54,7 @@ export async function removeSession(request: NextRequest, response: NextResponse
         console.warn("Client tried to logout without an existing sessionCookie in the logout request");
         return;
     }
-    response.cookies.set(sessionCookieName, sessionCookie, {
+    response.cookies.set(sessionCookieName, sessionCookie.value, {
         httpOnly: true,
         secure: process.env.NODE_ENV === "production",
         sameSite: "strict",

--- a/app/api/session/session.tsx
+++ b/app/api/session/session.tsx
@@ -50,6 +50,9 @@ export async function createSession({
 export async function removeSession(request: NextRequest, response: NextResponse) {
     const sessionCookieName = "session";
     const sessionCookie = request.cookies.get(sessionCookieName);
+    if (sessionCookie === undefined) {
+        console.warn("Client tried to logout without an existing sessionCookie in the logout request");
+    }
     response.cookies.set(sessionCookieName, sessionCookie, {
         httpOnly: true,
         secure: process.env.NODE_ENV === "production",

--- a/app/api/session/session.tsx
+++ b/app/api/session/session.tsx
@@ -1,6 +1,6 @@
 import "server-only";
 import { JWTPayload, SignJWT } from "jose";
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 
 const sessionSecretKey = process.env.SESSION_SECRET;
 const encodedKey = new TextEncoder().encode(sessionSecretKey);

--- a/app/api/session/session.tsx
+++ b/app/api/session/session.tsx
@@ -46,3 +46,15 @@ export async function createSession({
         maxAge: exp
     });
 }
+
+export async function removeSession(request: NextRequest, response: NextResponse) {
+    const sessionCookieName = "session";
+    const sessionCookie = request.cookies.get(sessionCookieName);
+    response.cookies.set(sessionCookieName, sessionCookie, {
+        httpOnly: true,
+        secure: process.env.NODE_ENV === "production",
+        sameSite: "strict",
+        path: "/",
+        maxAge: 0
+    });
+}


### PR DESCRIPTION
### Summary/Acceptance Criteria
As requested, splitting this up into two PRs (sub-issues) this is the first one which just does the work for the back-end which exposes an `/api/logout` endpoint which will respond with a `set-cookie` header for the session cookie setting its `max-age` to `0`

### Screenshots

#### Design 1... _(abandoned)_

<img width="711" height="150" alt="image" src="https://github.com/user-attachments/assets/eeafd17e-b732-4c39-b5c8-d77c21fc8071" />

#### Design 2...

<img width="932" height="140" alt="image" src="https://github.com/user-attachments/assets/d4635640-d8e1-4e1f-9645-f4c949c5901d" />


## Confirm
- [x] This PR has unit tests scenarios.
- [x] This PR is correctly linked to the relevant issue or milestone.
- [x] This PR has been locally QA'd.
- [ ] This PR has had it's db migrations run. (N/A no new data here)

/assign me
