### PR TITLE
323 log out

### DIFF
--- a/__tests__/components/navigation.js
+++ b/__tests__/components/navigation.js
@@ -1,5 +1,6 @@
 import { render, fireEvent, waitFor } from "@testing-library/react";
 import Navigation from "../../app/components/navigation/navigation";
+import { SessionProvider } from "../../app/contexts/session";
 
 describe("Navigation Component", () => {
     it("should render a hamburger navigation if there are pages found", async () => {
@@ -86,5 +87,49 @@ describe("Navigation Component", () => {
 
         const googleLoginButton = getByTestId("google-login-btn");
         expect(googleLoginButton).toBeVisible();
+    });
+
+    it("should render a logout button if the client does not have a session cookie", async () => {
+        const pages = [
+            {
+                name: "Current",
+                subpages: [
+                    {
+                        name: "Contestants",
+                        path: "/contestants",
+                    },
+                    {
+                        name: "Scoring",
+                        path: "/scoring",
+                    },
+                ],
+            },
+            {
+                name: "Past",
+                subpages: [
+                    {
+                        name: "Contestants",
+                        path: "/archive/contestants",
+                    },
+                ],
+            },
+        ];
+        const { getByTestId } = render(
+            <SessionProvider hasSessionCookie={true}>
+                <Navigation pages={pages} />
+            </SessionProvider>);
+        expect(getByTestId("navigation")).toBeTruthy();
+
+        const toggleButton = getByTestId("hamburger-nav-btn");
+        const navMenu = getByTestId("navigation-menu");
+        expect(toggleButton).toBeTruthy();
+        expect(navMenu).not.toBeVisible();
+        fireEvent.click(toggleButton);
+        waitFor(() => {
+            expect(navMenu).toBeVisible();
+        });
+
+        const logoutButton = getByTestId("logout-btn");
+        expect(logoutButton).toBeVisible();
     });
 });

--- a/__tests__/components/navigation.js
+++ b/__tests__/components/navigation.js
@@ -46,4 +46,45 @@ describe("Navigation Component", () => {
             expect(subPageList).toBeVisible();
         });
     });
+
+    it("should render a google login button if the client does not have a session cookie", async () => {
+        const pages = [
+            {
+                name: "Current",
+                subpages: [
+                    {
+                        name: "Contestants",
+                        path: "/contestants",
+                    },
+                    {
+                        name: "Scoring",
+                        path: "/scoring",
+                    },
+                ],
+            },
+            {
+                name: "Past",
+                subpages: [
+                    {
+                        name: "Contestants",
+                        path: "/archive/contestants",
+                    },
+                ],
+            },
+        ];
+        const { getByTestId } = render(<Navigation pages={pages} />);
+        expect(getByTestId("navigation")).toBeTruthy();
+
+        const toggleButton = getByTestId("hamburger-nav-btn");
+        const navMenu = getByTestId("navigation-menu");
+        expect(toggleButton).toBeTruthy();
+        expect(navMenu).not.toBeVisible();
+        fireEvent.click(toggleButton);
+        waitFor(() => {
+            expect(navMenu).toBeVisible();
+        });
+
+        const googleLoginButton = getByTestId("google-login-btn");
+        expect(googleLoginButton).toBeVisible();
+    });
 });

--- a/__tests__/components/navigation/logoutButton.js
+++ b/__tests__/components/navigation/logoutButton.js
@@ -1,5 +1,7 @@
 import { render, fireEvent } from "@testing-library/react";
 import LogoutButton from "../../../app/components/navigation/logoutButton.tsx";
+import React from "react"
+
 
 describe("LogoutButton", () => {
     it("should render", () => {

--- a/__tests__/components/navigation/logoutButton.js
+++ b/__tests__/components/navigation/logoutButton.js
@@ -18,4 +18,17 @@ describe("LogoutButton", () => {
         fireEvent.click(logoutButton);
         expect(window.fetch).toHaveBeenCalled();
     });
+
+    it("should resolve fetch response when it is clicked", () => {
+        const fetchPromise = { then: jest.fn((resolve) => {
+            resolve({/* http response */});
+        })};
+        window.fetch = jest.fn()
+            .mockImplementation(() => fetchPromise);
+
+        const { getByTestId } = render(<LogoutButton/>);
+        const logoutButton = getByTestId("logout-button-core");
+        fireEvent.click(logoutButton);
+        expect(fetchPromise.then).toHaveBeenCalled()
+    });
 });

--- a/__tests__/components/navigation/logoutButton.js
+++ b/__tests__/components/navigation/logoutButton.js
@@ -5,4 +5,17 @@ describe("LogoutButton", () => {
     it("should render", () => {
         render(<LogoutButton/>);
     });
+
+    it("should make an api call when it is clicked", () => {
+        const fetchPromise = { then: jest.fn((resolve) => {
+            resolve({/* http response */});
+        })};
+        window.fetch = jest.fn()
+            .mockImplementation(() => fetchPromise);
+
+        const { getByTestId } = render(<LogoutButton/>);
+        const logoutButton = getByTestId("logout-button-core");
+        fireEvent.click(logoutButton);
+        expect(window.fetch).toHaveBeenCalled();
+    });
 });

--- a/__tests__/components/navigation/logoutButton.js
+++ b/__tests__/components/navigation/logoutButton.js
@@ -1,4 +1,4 @@
-import { render } from "@testing-library/react";
+import { render, fireEvent } from "@testing-library/react";
 import LogoutButton from "../../../app/components/navigation/logoutButton.tsx";
 
 describe("LogoutButton", () => {

--- a/__tests__/components/navigation/logoutButton.js
+++ b/__tests__/components/navigation/logoutButton.js
@@ -33,4 +33,22 @@ describe("LogoutButton", () => {
         fireEvent.click(logoutButton);
         expect(fetchPromise.then).toHaveBeenCalled()
     });
+
+    it("should call set on sessionContext when a 205 is returned", () => {
+        const fetchPromise = { then: jest.fn((resolve) => {
+            resolve({status: 205});
+        })};
+        window.fetch = jest.fn()
+            .mockImplementation(() => fetchPromise);
+        const setIsLoggedInMock = jest.fn();
+        jest.spyOn(React, "useContext").mockReturnValue({ setIsLoggedIn: setIsLoggedInMock });
+
+        const { getByTestId } = render(
+            <LogoutButton/>
+        );
+        const logoutButton = getByTestId("logout-button-core");
+        fireEvent.click(logoutButton);
+
+        expect(setIsLoggedInMock).toHaveBeenCalled();
+    });
 });

--- a/__tests__/components/navigation/logoutButton.js
+++ b/__tests__/components/navigation/logoutButton.js
@@ -1,0 +1,8 @@
+import { render } from "@testing-library/react";
+import LogoutButton from "../../../app/components/navigation/logoutButton.tsx";
+
+describe("LogoutButton", () => {
+    it("should render", () => {
+        render(<LogoutButton/>);
+    });
+});

--- a/app/components/navigation/logoutButton.tsx
+++ b/app/components/navigation/logoutButton.tsx
@@ -9,7 +9,11 @@ export default function LogoutButton(){
         fetch("/api/logout", {
             method: "POST"
         }).then((resp) => {
-            console.log(resp);
+            if (resp.status === 205) {
+                setIsLoggedIn(false);
+            } else {
+                console.warn(`Unexpected status code back from /api/logout: '${resp.status}'`);
+            }
         });
     }
 

--- a/app/components/navigation/logoutButton.tsx
+++ b/app/components/navigation/logoutButton.tsx
@@ -1,0 +1,8 @@
+"use client"
+
+export default function LogoutButton(){
+
+    return (<>
+        <button >Log Out</button>
+    </>);
+}

--- a/app/components/navigation/logoutButton.tsx
+++ b/app/components/navigation/logoutButton.tsx
@@ -6,9 +6,10 @@ export default function LogoutButton(){
     const { setIsLoggedIn } = useContext(SessionContext);
 
     function performLogout() {
-        fetch("/api/logout", {
+        const result = fetch("/api/logout", {
             method: "POST"
-        }).then((resp) => {
+        });
+        result.then((resp) => {
             if (resp.status === 205) {
                 setIsLoggedIn(false);
             } else {

--- a/app/components/navigation/logoutButton.tsx
+++ b/app/components/navigation/logoutButton.tsx
@@ -1,6 +1,9 @@
 "use client"
+import { useContext } from "react";
+import { SessionContext } from "@/app/contexts/session";
 
 export default function LogoutButton(){
+    const { setIsLoggedIn } = useContext(SessionContext);
 
     function performLogout() {
         fetch("/api/logout", {

--- a/app/components/navigation/logoutButton.tsx
+++ b/app/components/navigation/logoutButton.tsx
@@ -2,7 +2,15 @@
 
 export default function LogoutButton(){
 
+    function performLogout() {
+        fetch("/api/logout", {
+            method: "POST"
+        }).then((resp) => {
+            console.log(resp);
+        });
+    }
+
     return (<>
-        <button >Log Out</button>
+        <button onClick={performLogout}>Log Out</button>
     </>);
 }

--- a/app/components/navigation/logoutButton.tsx
+++ b/app/components/navigation/logoutButton.tsx
@@ -18,6 +18,7 @@ export default function LogoutButton(){
     }
 
     return (<>
-        <button onClick={performLogout}>Log Out</button>
+        <button data-testid="logout-button-core" onClick={performLogout}>Log Out</button>
     </>);
 }
+

--- a/app/components/navigation/navigation-item.tsx
+++ b/app/components/navigation/navigation-item.tsx
@@ -10,9 +10,7 @@ export default function NavigationItem({
 }: INavigationItem) {
     const [isExpanded, setIsExpanded] = useState(false);
     useEffect(()=> {
-        if(navigationClose){
-            setIsExpanded(false);
-        }
+        setIsExpanded(false);
     }, [navigationClose]);
     return (<>
         <input 

--- a/app/components/navigation/navigation.tsx
+++ b/app/components/navigation/navigation.tsx
@@ -7,6 +7,7 @@ import NavigationItem from "./navigation-item";
 import GoogleLoginButton from "./google-login-btn";
 import { useContext } from "react";
 import { SessionContext } from "@/app/contexts/session";
+import LogoutButton from "@/app/components/navigation/logoutButton"
 
 export default function Navigation({ pages }: {
     pages: IPage[]
@@ -70,7 +71,9 @@ export default function Navigation({ pages }: {
                             })} />
                     </li>);
                 })}
-                { !isLoggedIn && <li className={styles["top-level-link"]} data-testid="google-login-btn" key={"nav-toplevellink-login"}><GoogleLoginButton/></li> }
+                { !isLoggedIn ?
+                    <li className={styles["top-level-link"]} data-testid="google-login-btn" key={"nav-toplevellink-login"}><GoogleLoginButton/></li>
+                    : <li className={styles["top-level-link"]} key={"nav-toplevellink-logout"}><LogoutButton/></li>}
                 </>} />
     </nav>);
 }

--- a/app/components/navigation/navigation.tsx
+++ b/app/components/navigation/navigation.tsx
@@ -73,7 +73,7 @@ export default function Navigation({ pages }: {
                 })}
                 { !isLoggedIn ?
                     <li className={styles["top-level-link"]} data-testid="google-login-btn" key={"nav-toplevellink-login"}><GoogleLoginButton/></li>
-                    : <li className={styles["top-level-link"]} key={"nav-toplevellink-logout"}><LogoutButton/></li>}
+                    : <li className={styles["top-level-link"]} data-testid="logout-btn" key={"nav-toplevellink-logout"}><LogoutButton/></li>}
                 </>} />
     </nav>);
 }


### PR DESCRIPTION
### Summary/Acceptance Criteria
So far the expectation of this PR is to "draw the rest of the owl" on logout. Once complete users should be able to "logout" of the site effectively meaning they no longer have an active usable session with the site.

### Screenshots
Before logging in:
<img width="802" height="367" alt="image" src="https://github.com/user-attachments/assets/55c4bb58-ccc3-452f-b5f0-1cb1ecc652fd" />

After logging in:
<img width="805" height="358" alt="image" src="https://github.com/user-attachments/assets/8251d44f-3c2b-4bcd-a730-90bfc44758d1" />

_then it goes back to the before login_

## Confirm
- [x] This PR has unit tests scenarios.
- [x] This PR is correctly linked to the relevant issue or milestone.
- [x] This PR has been locally QA'd.
- [ ] This PR has had it's db migrations run. (N/A no new data here)


### TODO::
- [x] Determine how to do tests where we can mock fetch
  - [x] Determine how to get through working with `SessionProvider` in a unit test
    - _worked through this by mocking the react hook entirely which should be fine for a unit test_
- [x] Verify the change to navigation-item is correct
- [ ] ~Figure out how to mock next router~ (Moved to #345)
    - [ ] ~this enables us to add a `push` redirect on-logout forcing the client to go to root~ (Moved to #345)
- [x] Verify that we want to update the api response to be 205 (this could change scope on #341 a lil bit)

/assign me
