### PR TITLE
Feature/remove config clearing

### DIFF
--- a/scripts/seedDb.mjs
+++ b/scripts/seedDb.mjs
@@ -83,16 +83,3 @@ async function recreateLeagueConfigurationData(leagueConfigurationKey, dataRepo)
     await redis.json.set(leagueConfigurationKey, "$", leagueConfigString)
 }
 
-async function deleteAllLeagueConfigurationData() {
-    let leagueConfigurationCursor = await redis.scan("0", {match: "league_configuration:*"});
-    let leagueConfigurationKeys = leagueConfigurationCursor[1];
-    let cursorStart = leagueConfigurationCursor[0];
-    while(cursorStart !== "0"){
-        leagueConfigurationCursor = await redis.scan(cursorStart, {match: "league_configuration:*"});
-        leagueConfigurationKeys = leagueConfigurationKeys.concat(leagueConfigurationCursor[1]);
-        cursorStart = leagueConfigurationCursor[0];
-    }
-    for(const leagueConfigurationKey of leagueConfigurationKeys){
-        redis.del(leagueConfigurationKey);
-    }
-}


### PR DESCRIPTION
### Summary/Acceptance Criteria
Since enabling league configs to be written using a form from the on-line site we don't have a need to start fresh everytime the db gets seeded. If/when we need to update old leagues we are hoping that it can be done through the form then backed up w/ the rest of the db. 

_note: Since this is a change to the seed db script if one needs to refresh the dev db they will either need to do that from prod or using the script but recognizing it will only "upsert." if anything needs to be removed, that needs to be done manually_

### Screenshots
(N/A) backend change

## Confirm
- [ ] This PR has unit tests scenarios. (we aren't testing these scripts)
- [x] This PR is correctly linked to the relevant issue or milestone.
- [x] This PR has been locally QA'd.
- [ ] This PR has had it's db migrations run. (no new data despite this changing the migration)

/assign me
