### PR TITLE
Bugfix/fixing isparticipating for survivor

### DIFF
--- a/app/parsers/survivorEntityParser.tsx
+++ b/app/parsers/survivorEntityParser.tsx
@@ -75,7 +75,6 @@ export default function parseSurvivorEntities(contestantData :ITableRowData[]): 
                 // starting with the eliminated contestant we are going to try
                 // assuming true and assign no finishing day
                 isParticipating = true;
-                //foundContestant.finishDay = foundContestant.finishDay + 0.5; // accounts for the default ordering where the person who come first was actually evicted last
             }
         }
 


### PR DESCRIPTION
### Summary/Acceptance Criteria
After creating a new league for Survivor 49, we discovered that because of some bug all the contestants were crossed out (means they were determined to be set `isParticipating: false` (see screenshot). After doing some research it was revealed that this is because an assumption was made that while processing all contestants in order once we have seen one contestant eliminated all others should also be eliminated. This assumptions works (and may have even been necessary to assume to fix #136) but only if the eliminations are at the bottom of the list, but IIRC this does not tend to be the case for Survivor. After tweaking a couple of details about how `finishDay` and `isParticipating` the list no renders the way we expect.

### Screenshots
_Before:_
<img width="848" height="704" alt="image" src="https://github.com/user-attachments/assets/7c7d6e6e-1769-4bc2-97eb-9760bd22ccfd" />

_After:_
<img width="543" height="703" alt="image" src="https://github.com/user-attachments/assets/b998c8ac-fa74-4413-9b7a-902ce79c82c7" />

## Confirm
- [ ] This PR has unit tests scenarios. (TBD, trying to decide if this makes sense)
- [x] This PR is correctly linked to the relevant issue or milestone.
- [x] This PR has been locally QA'd.
- [ ] This PR has had it's db migrations run. (N/A no new data)

/assign me
