### PR TITLE
Bugfix/fix survivor names

### DIFF
--- a/app/leagueData/Survivor_49.js
+++ b/app/leagueData/Survivor_49.js
@@ -4,27 +4,27 @@ const CONTESTANT_LEAGUE_DATA = [
     {
         name: "Antoinette",
         userId: "DCC9DCDC-AE5C-4A53-AF09-23F3C957D60B",
-        ranking: [ "Jeremiah Ing", "Savannah Louie", "Jason Treul", "Rizo Velovic", "Sage Ahrens-Nichols", "Sophi Balerdi", "Steven Ramm", "Michelle \"MC\" Chukwujekwu", "Shannon Fairweather", "Matt Williams", "Jawan Pitts", "Kristina Mills", "Sophia \"Sophie\" Segreti ", "Kimberly \"Annie\" Davis", "Jake Latimer", "Nate Moore", "Alex Moore", "Nicole Mazullo" ]
+        ranking: [ "Jeremiah Ing", "Savannah Louie", "Jason Treul", "Rizo Velovic", "Sage Ahrens-Nichols", "Sophi Balerdi", "Steven Ramm", "Michelle \"MC\" Chukwujekwu", "Shannon Fairweather", "Matt Williams", "Jawan Pitts", "Kristina Mills", "Sophie Segreti", "Kimberly \"Annie\" Davis", "Jake Latimer", "Nate Moore", "Alex Moore", "Nicole Mazullo" ]
     },
     {
         name: "Cindy",
         userId: "685AAAF4-97DB-4266-A0B7-E61E2C6CA22E",
-        ranking: [ "Jake Latimer", "Savannah Louie", "Matt Williams", "Jeremiah Ing", "Michelle \"MC\" Chukwujekwu", "Alex Moore", "Sophi Balerdi", "Sage Ahrens-Nichols", "Shannon Fairweather", "Jawan Pitts", "Sophia \"Sophie\" Segreti ", "Steven Ramm", "Kristina Mills", "Rizo Velovic", "Nate Moore", "Jason Treul", "Kimberly \"Annie\" Davis", "Nicole Mazullo" ]
+        ranking: [ "Jake Latimer", "Savannah Louie", "Matt Williams", "Jeremiah Ing", "Michelle \"MC\" Chukwujekwu", "Alex Moore", "Sophi Balerdi", "Sage Ahrens-Nichols", "Shannon Fairweather", "Jawan Pitts", "Sophie Segreti", "Steven Ramm", "Kristina Mills", "Rizo Velovic", "Nate Moore", "Jason Treul", "Kimberly \"Annie\" Davis", "Nicole Mazullo" ]
     },
     {
         name: "Jacob",
         userId: "C7D10281-8879-4F41-929B-723EFBE4A1C4",
-        ranking: [ "Jake Latimer", "Michelle \"MC\" Chukwujekwu", "Savannah Louie", "Shannon Fairweather", "Sage Ahrens-Nichols", "Sophia \"Sophie\" Segreti ", "Nate Moore", "Rizo Velovic", "Alex Moore", "Matt Williams", "Jason Treul", "Jawan Pitts", "Sophi Balerdi", "Steven Ramm", "Jeremiah Ing", "Kimberly \"Annie\" Davis", "Kristina Mills", "Nicole Mazullo" ]
+        ranking: [ "Jake Latimer", "Michelle \"MC\" Chukwujekwu", "Savannah Louie", "Shannon Fairweather", "Sage Ahrens-Nichols", "Sophie Segreti", "Nate Moore", "Rizo Velovic", "Alex Moore", "Matt Williams", "Jason Treul", "Jawan Pitts", "Sophi Balerdi", "Steven Ramm", "Jeremiah Ing", "Kimberly \"Annie\" Davis", "Kristina Mills", "Nicole Mazullo" ]
     },
     {
         name: "Jenny",
         userId: "894B180E-A635-41BA-B6BC-B0AC84AE7B23",
-        ranking: [ "Savannah Louie", "Jeremiah Ing", "Jason Treul", "Rizo Velovic", "Sophia \"Sophie\" Segreti ", "Kristina Mills", "Steven Ramm", "Sage Ahrens-Nichols", "Michelle \"MC\" Chukwujekwu", "Jake Latimer", "Matt Williams", "Jawan Pitts", "Sophi Balerdi", "Alex Moore", "Shannon Fairweather", "Nate Moore", "Kimberly \"Annie\" Davis", "Nicole Mazullo" ]
+        ranking: [ "Savannah Louie", "Jeremiah Ing", "Jason Treul", "Rizo Velovic", "Sophie Segreti", "Kristina Mills", "Steven Ramm", "Sage Ahrens-Nichols", "Michelle \"MC\" Chukwujekwu", "Jake Latimer", "Matt Williams", "Jawan Pitts", "Sophi Balerdi", "Alex Moore", "Shannon Fairweather", "Nate Moore", "Kimberly \"Annie\" Davis", "Nicole Mazullo" ]
     },
     {
         name: "Sam",
         userId: "CD9F9A71-FF9C-416A-8D0D-C268A13B021F",
-        ranking: [ "Savannah Louie", "Sage Ahrens-Nichols", "Nate Moore", "Jeremiah Ing", "Kristina Mills", "Sophi Balerdi", "Alex Moore", "Shannon Fairweather", "Jake Latimer", "Jawan Pitts", "Jason Treul", "Michelle \"MC\" Chukwujekwu", "Steven Ramm", "Sophia \"Sophie\" Segreti ", "Matt Williams", "Rizo Velovic", "Kimberly \"Annie\" Davis", "Nicole Mazullo" ]
+        ranking: [ "Savannah Louie", "Sage Ahrens-Nichols", "Nate Moore", "Jeremiah Ing", "Kristina Mills", "Sophi Balerdi", "Alex Moore", "Shannon Fairweather", "Jake Latimer", "Jawan Pitts", "Jason Treul", "Michelle \"MC\" Chukwujekwu", "Steven Ramm", "Sophie Segreti", "Matt Williams", "Rizo Velovic", "Kimberly \"Annie\" Davis", "Nicole Mazullo" ]
     }
 ];
 


### PR DESCRIPTION
### Summary/Acceptance Criteria
The survivor league was broken because of our source data changing from Wikipedia, here is a smol change to fix it.

### Screenshots
N/A (it didn't work before and now it does)

## Confirm
- [ ] This PR has unit tests scenarios. (N/A just a data change nothing more we can do)
- [x] This PR is correctly linked to the relevant issue or milestone.
- [x] This PR has been locally QA'd.
- [x] This PR has had it's db migrations run.

/assign me
