### PR TITLE
Converted IContestantRoundData

### DIFF
--- a/app/components/contestantRoundList.tsx
+++ b/app/components/contestantRoundList.tsx
@@ -1,7 +1,7 @@
 import Round from "./round";
 import CompetingEntity from "../models/CompetingEntity";
 import IRound from "../models/IRound";
-import IContestantRoundData from "../models/IContestantRoundData";
+import { ContestantRoundData } from "../models/ContestantRoundData";
 
 export default function ContestantRoundList({
     perfectRoundScores,
@@ -24,12 +24,12 @@ export default function ContestantRoundList({
                     console.warn("Something is wrong that the rounds are out of order");
                 }
 
-                const perfectRound = round.contestantRoundData.filter((x: IContestantRoundData) => x.name === "*perfect*")[0];
+                const perfectRound = round.contestantRoundData.filter((x: ContestantRoundData) => x.name === "*perfect*")[0];
                 const perfectScore = perfectRound.roundScore;
                 const grandTotal = perfectRound.totalScore;
 
                 const contestantRound = contestantRoundScores[roundNumber]; // check round number
-                const filteredContestantRound = contestantRound.contestantRoundData.filter((x: IContestantRoundData) => x.name === contestantName)[0];
+                const filteredContestantRound = contestantRound.contestantRoundData.filter((x: ContestantRoundData) => x.name === contestantName)[0];
                 const contestantRoundScore = filteredContestantRound.roundScore;
                 const contestantGrandTotal = filteredContestantRound.totalScore;
 

--- a/app/models/ContestantRoundData.tsx
+++ b/app/models/ContestantRoundData.tsx
@@ -1,4 +1,4 @@
-export default interface IContestantRoundData {
+export type ContestantRoundData ={
     name: string
     roundScore: number
     totalScore: number

--- a/app/models/IRound.tsx
+++ b/app/models/IRound.tsx
@@ -1,8 +1,8 @@
-import IContestantRoundData from "./IContestantRoundData";
+import { ContestantRoundData } from "./ContestantRoundData";
 
 export default interface IRound {
     round: number
     eliminationOrder: number
     teamsEliminatedSoFar: number
-    contestantRoundData: IContestantRoundData[]
+    contestantRoundData: ContestantRoundData[]
 };

--- a/app/models/League.tsx
+++ b/app/models/League.tsx
@@ -1,5 +1,5 @@
 import IRound from "./IRound";
-import IContestantRoundData from "./IContestantRoundData";
+import { ContestantRoundData } from "./ContestantRoundData";
 import CompetingEntity from "./CompetingEntity";
 import { shouldBeScored, getNumberOfTeamsToEliminate, getRoundEliminationOrderMapping, getUniqueEliminationOrders, convertNamesToTeamList } from "../utils/teamListUtils";
 
@@ -70,7 +70,7 @@ export default class League {
         contestantTeamsList: CompetingEntity[],
         contestantName: string,
         handicap: number,
-        addToRoundList: (_n: number, _eo: number, _cot: number, _crd: IContestantRoundData) => void
+        addToRoundList: (_n: number, _eo: number, _cot: number, _crd: ContestantRoundData) => void
     ): void {
 
         let grandTotal = handicap === undefined ? 0 : handicap;


### PR DESCRIPTION
### Summary/Acceptance Criteria

I migrated IContestantRoundData both to the correct naming convention as well as to a type instead of interface. Refactoring the table code informed me that we need the type to be indexable, which is only in mappable types. Interfaces are not mappable. Learn more here: https://www.typescriptlang.org/docs/handbook/2/mapped-types.html

## Confirm
- [ ] This PR has unit tests scenarios. (N/A)
- [x] This PR is correctly linked to the relevant issue or milestone.
- [ ] This PR has been locally QA'd. (N/A)
- [ ] This PR has had it's db migrations run. (N/A)
- [ ] Update documentation. (N/A)
