### PR TITLE
442 add league update endpoint

### DIFF
--- a/__tests__/api/league/route.js
+++ b/__tests__/api/league/route.js
@@ -866,6 +866,23 @@ describe("PUT (unit tests)", () => {
 
     it("should return 200 when PUT conditions met", async () => {
         // Arrange
+        const dbWikiPageUrl = "https://en.wikipedia.org/wiki/Original_Page";
+        const dbWikiApiUrl = "https://en.wikipedia.org/w/api.php?action=parse&format=json&page=Original_Page";
+        const dbCastPhrase = "Original Cast";
+        const dbCompetitingEntityName = "person";
+        const dbContestantLeagueDataKeyPrefix = `${happyPathRequest.leagueKey}:*`;
+        
+        getLeagueConfigurationData.mockImplementation(() => {
+            return Promise.resolve({
+                createdBy: ourUserId,
+                wikiPageUrl: dbWikiPageUrl,
+                wikiApiUrl: dbWikiApiUrl,
+                castPhrase: dbCastPhrase,
+                competitingEntityName: dbCompetitingEntityName,
+                contestantLeagueDataKeyPrefix: dbContestantLeagueDataKeyPrefix
+            });
+        });
+
         const request = {
             cookies: {
                 get: jest.fn().mockImplementation(()=> {
@@ -873,11 +890,7 @@ describe("PUT (unit tests)", () => {
                 })
             },
             json: jest.fn().mockImplementation(async () => {
-                return {
-                    ...happyPathRequest,
-                    wikiPageUrl: `https://en.wikipedia.org/wiki/${happyPathRequest.wikiPageName}`,
-                    wikiApiUrl: `https://en.wikipedia.org/w/api.php?action=parse&format=json&page=${happyPathRequest.wikiPageName}`
-                };
+                return happyPathRequest;
             })
         };
 
@@ -890,9 +903,10 @@ describe("PUT (unit tests)", () => {
         expect(request.json).toHaveBeenCalledTimes(1);
         expect(writeLeagueConfigurationData).toHaveBeenCalledTimes(1);
         expect(writeLeagueConfigurationData).toHaveBeenCalledWith(
-            `league_configuration:${happyPathRequest.leagueStatus}:${happyPathRequest.leagueKey}`,
+            `league_configuration:${happyPathRequest.leagueStatus}:${dbContestantLeagueDataKeyPrefix}`,
             expect.objectContaining({
-                googleSheetUrl: happyPathRequest.googleSheetUrl
+                googleSheetUrl: happyPathRequest.googleSheetUrl,
+                leagueStatus: happyPathRequest.leagueStatus
             })
         );
     });
@@ -909,11 +923,7 @@ describe("PUT (unit tests)", () => {
                 })
             },
             json: jest.fn().mockImplementation(async () => {
-                return {
-                    ...happyPathRequest,
-                    wikiPageUrl: `https://en.wikipedia.org/wiki/${happyPathRequest.wikiPageName}`,
-                    wikiApiUrl: `https://en.wikipedia.org/w/api.php?action=parse&format=json&page=${happyPathRequest.wikiPageName}`
-                };
+                return happyPathRequest;
             })
         };
 
@@ -940,11 +950,7 @@ describe("PUT (unit tests)", () => {
                 })
             },
             json: jest.fn().mockImplementation(async () => {
-                return {
-                    ...happyPathRequest,
-                    wikiPageUrl: `https://en.wikipedia.org/wiki/${happyPathRequest.wikiPageName}`,
-                    wikiApiUrl: `https://en.wikipedia.org/w/api.php?action=parse&format=json&page=${happyPathRequest.wikiPageName}`
-                };
+                return happyPathRequest;
             })
         };
 
@@ -970,11 +976,7 @@ describe("PUT (unit tests)", () => {
                 })
             },
             json: jest.fn().mockImplementation(async () => {
-                return {
-                    ...happyPathRequest,
-                    wikiPageUrl: `https://en.wikipedia.org/wiki/${happyPathRequest.wikiPageName}`,
-                    wikiApiUrl: `https://en.wikipedia.org/w/api.php?action=parse&format=json&page=${happyPathRequest.wikiPageName}`
-                };
+                return happyPathRequest;
             })
         };
 
@@ -990,9 +992,7 @@ describe("PUT (unit tests)", () => {
         // Arrange
         const invalidRequestBody = {
             ...happyPathRequest,
-            leagueStatus: "maybe-active",
-            wikiPageUrl: `https://en.wikipedia.org/wiki/${happyPathRequest.wikiPageName}`,
-            wikiApiUrl: `https://en.wikipedia.org/w/api.php?action=parse&format=json&page=${happyPathRequest.wikiPageName}`
+            leagueStatus: "maybe-active"
         };
         const request = {
             cookies: {
@@ -1015,10 +1015,66 @@ describe("PUT (unit tests)", () => {
         expect(bodyString).toContain("leagueStatus");
     });
 
-    it("should use wikiPageUrl and wikiApiUrl from request body when updating", async () => {
+    it("should use wikiPageUrl and wikiApiUrl from database when updating", async () => {
         // Arrange
-        const customWikiPageUrl = "https://en.wikipedia.org/wiki/Custom_Page";
-        const customWikiApiUrl = "https://en.wikipedia.org/w/api.php?action=parse&format=json&page=Custom_Page";
+        const dbWikiPageUrl = "https://en.wikipedia.org/wiki/Database_Page";
+        const dbWikiApiUrl = "https://en.wikipedia.org/w/api.php?action=parse&format=json&page=Database_Page";
+        const dbContestantLeagueDataKeyPrefix = `${happyPathRequest.leagueKey}:*`;
+        
+        getLeagueConfigurationData.mockImplementation(() => {
+            return Promise.resolve({
+                createdBy: ourUserId,
+                wikiPageUrl: dbWikiPageUrl,
+                wikiApiUrl: dbWikiApiUrl,
+                castPhrase: "Cast",
+                competitingEntityName: "person",
+                contestantLeagueDataKeyPrefix: dbContestantLeagueDataKeyPrefix
+            });
+        });
+
+        const request = {
+            cookies: {
+                get: jest.fn().mockImplementation(()=> {
+                    return "testToken"
+                })
+            },
+            json: jest.fn().mockImplementation(async () => {
+                return happyPathRequest;
+            })
+        };
+
+        // Act
+        const response = await PUT(request);
+
+        // Assert
+        expect(response).not.toBeNull();
+        expect(response.status).toEqual(200);
+        expect(writeLeagueConfigurationData).toHaveBeenCalledWith(
+            expect.anything(),
+            expect.objectContaining({
+                wikiPageUrl: dbWikiPageUrl,
+                wikiApiUrl: dbWikiApiUrl
+            })
+        );
+    });
+
+    it("should use castPhrase and competitingEntityName from database when updating", async () => {
+        // Arrange
+        const dbCastPhrase = "Original Cast";
+        const dbCompetitingEntityName = "person";
+        const dbContestantLeagueDataKeyPrefix = `${happyPathRequest.leagueKey}:*`;
+        
+        getLeagueConfigurationData.mockImplementation(() => {
+            return Promise.resolve({
+                createdBy: ourUserId,
+                wikiPageUrl: "https://en.wikipedia.org/wiki/Page",
+                wikiApiUrl: "https://en.wikipedia.org/w/api.php",
+                castPhrase: dbCastPhrase,
+                competitingEntityName: dbCompetitingEntityName,
+                contestantLeagueDataKeyPrefix: dbContestantLeagueDataKeyPrefix
+            });
+        });
+
         const request = {
             cookies: {
                 get: jest.fn().mockImplementation(()=> {
@@ -1028,8 +1084,8 @@ describe("PUT (unit tests)", () => {
             json: jest.fn().mockImplementation(async () => {
                 return {
                     ...happyPathRequest,
-                    wikiPageUrl: customWikiPageUrl,
-                    wikiApiUrl: customWikiApiUrl
+                    castPhrase: "Different Cast",
+                    contestantType: "team"
                 };
             })
         };
@@ -1043,8 +1099,8 @@ describe("PUT (unit tests)", () => {
         expect(writeLeagueConfigurationData).toHaveBeenCalledWith(
             expect.anything(),
             expect.objectContaining({
-                wikiPageUrl: customWikiPageUrl,
-                wikiApiUrl: customWikiApiUrl
+                castPhrase: dbCastPhrase,
+                competitingEntityName: dbCompetitingEntityName
             })
         );
     });
@@ -1058,11 +1114,7 @@ describe("PUT (unit tests)", () => {
                 })
             },
             json: jest.fn().mockImplementation(async () => {
-                return {
-                    ...happyPathRequest,
-                    wikiPageUrl: `https://en.wikipedia.org/wiki/${happyPathRequest.wikiPageName}`,
-                    wikiApiUrl: `https://en.wikipedia.org/w/api.php?action=parse&format=json&page=${happyPathRequest.wikiPageName}`
-                };
+                return happyPathRequest;
             })
         };
 
@@ -1072,5 +1124,42 @@ describe("PUT (unit tests)", () => {
         // Assert
         expect(response).not.toBeNull();
         expect(getAllKeys).toHaveBeenCalledWith(`league_configuration:*:${happyPathRequest.leagueKey}`);
+    });
+
+    it("should construct the write key using database contestantLeagueDataKeyPrefix", async () => {
+        // Arrange
+        const dbContestantLeagueDataKeyPrefix = `${happyPathRequest.leagueKey}:*`;
+        getLeagueConfigurationData.mockImplementation(() => {
+            return Promise.resolve({
+                createdBy: ourUserId,
+                wikiPageUrl: "https://en.wikipedia.org/wiki/Page",
+                wikiApiUrl: "https://en.wikipedia.org/w/api.php",
+                castPhrase: "Cast",
+                competitingEntityName: "person",
+                contestantLeagueDataKeyPrefix: dbContestantLeagueDataKeyPrefix
+            });
+        });
+
+        const request = {
+            cookies: {
+                get: jest.fn().mockImplementation(()=> {
+                    return "testToken"
+                })
+            },
+            json: jest.fn().mockImplementation(async () => {
+                return happyPathRequest;
+            })
+        };
+
+        // Act
+        const response = await PUT(request);
+
+        // Assert
+        expect(response).not.toBeNull();
+        expect(response.status).toEqual(200);
+        expect(writeLeagueConfigurationData).toHaveBeenCalledWith(
+            `league_configuration:${happyPathRequest.leagueStatus}:${dbContestantLeagueDataKeyPrefix}`,
+            expect.anything()
+        );
     });
 });

--- a/__tests__/api/league/route.js
+++ b/__tests__/api/league/route.js
@@ -6,7 +6,7 @@ jest.mock("google-auth-library");
 jest.mock("../../../app/dataSources/dbFetch");
 import * as sessionModule from "../../../app/api/session/session";
 import { OAuth2Client } from "google-auth-library";
-import { writeLeagueConfigurationData, getUser } from "@/app/dataSources/dbFetch";
+import { writeLeagueConfigurationData, getUser, getAllKeys, getLeagueConfigurationData } from "@/app/dataSources/dbFetch";
 import { POST, PUT } from "@/app/api/league/route.ts";
 
 let testAuthData = {}
@@ -852,6 +852,18 @@ describe("POST (unit tests)", () => {
 });
 
 describe("PUT (unit tests)", () => {
+    beforeEach(() => {
+        getAllKeys.mockImplementation(() => {
+            return Promise.resolve([`league_configuration:${happyPathRequest.leagueStatus}:${happyPathRequest.leagueKey}`]);
+        });
+
+        getLeagueConfigurationData.mockImplementation(() => {
+            return Promise.resolve({
+                createdBy: ourUserId
+            });
+        });
+    });
+
     it("should return 200 when PUT conditions met", async () => {
         // Arrange
         const request = {
@@ -863,7 +875,6 @@ describe("PUT (unit tests)", () => {
             json: jest.fn().mockImplementation(async () => {
                 return {
                     ...happyPathRequest,
-                    createdBy: ourUserId,
                     wikiPageUrl: `https://en.wikipedia.org/wiki/${happyPathRequest.wikiPageName}`,
                     wikiApiUrl: `https://en.wikipedia.org/w/api.php?action=parse&format=json&page=${happyPathRequest.wikiPageName}`
                 };
@@ -881,14 +892,16 @@ describe("PUT (unit tests)", () => {
         expect(writeLeagueConfigurationData).toHaveBeenCalledWith(
             `league_configuration:${happyPathRequest.leagueStatus}:${happyPathRequest.leagueKey}`,
             expect.objectContaining({
-                googleSheetUrl: happyPathRequest.googleSheetUrl,
-                createdBy: ourUserId
+                googleSheetUrl: happyPathRequest.googleSheetUrl
             })
         );
     });
 
-    it("should return a 403 when PUT createdBy does not match session user", async () => {
+    it("should return a 404 when no league configuration found", async () => {
         // Arrange
+        getAllKeys.mockImplementation(() => {
+            return Promise.resolve([]);
+        });
         const request = {
             cookies: {
                 get: jest.fn().mockImplementation(()=> {
@@ -898,7 +911,67 @@ describe("PUT (unit tests)", () => {
             json: jest.fn().mockImplementation(async () => {
                 return {
                     ...happyPathRequest,
-                    createdBy: "differentUser",
+                    wikiPageUrl: `https://en.wikipedia.org/wiki/${happyPathRequest.wikiPageName}`,
+                    wikiApiUrl: `https://en.wikipedia.org/w/api.php?action=parse&format=json&page=${happyPathRequest.wikiPageName}`
+                };
+            })
+        };
+
+        // Act
+        const response = await PUT(request);
+
+        // Assert
+        expect(response).not.toBeNull();
+        expect(response.status).toEqual(404);
+    });
+
+    it("should return a 500 when multiple league configurations found", async () => {
+        // Arrange
+        getAllKeys.mockImplementation(() => {
+            return Promise.resolve([
+                `league_configuration:active:${happyPathRequest.leagueKey}`,
+                `league_configuration:inactive:${happyPathRequest.leagueKey}`
+            ]);
+        });
+        const request = {
+            cookies: {
+                get: jest.fn().mockImplementation(()=> {
+                    return "testToken"
+                })
+            },
+            json: jest.fn().mockImplementation(async () => {
+                return {
+                    ...happyPathRequest,
+                    wikiPageUrl: `https://en.wikipedia.org/wiki/${happyPathRequest.wikiPageName}`,
+                    wikiApiUrl: `https://en.wikipedia.org/w/api.php?action=parse&format=json&page=${happyPathRequest.wikiPageName}`
+                };
+            })
+        };
+
+        // Act
+        const response = await PUT(request);
+
+        // Assert
+        expect(response).not.toBeNull();
+        expect(response.status).toEqual(500);
+    });
+
+    it("should return a 403 when PUT userId does not match createdBy from database", async () => {
+        // Arrange
+        getLeagueConfigurationData.mockImplementation(() => {
+            return Promise.resolve({
+                createdBy: "differentUser"
+            });
+        });
+        const request = {
+            cookies: {
+                get: jest.fn().mockImplementation(()=> {
+                    return "testToken"
+                })
+            },
+            json: jest.fn().mockImplementation(async () => {
+                return {
+                    ...happyPathRequest,
                     wikiPageUrl: `https://en.wikipedia.org/wiki/${happyPathRequest.wikiPageName}`,
                     wikiApiUrl: `https://en.wikipedia.org/w/api.php?action=parse&format=json&page=${happyPathRequest.wikiPageName}`
                 };
@@ -917,7 +990,6 @@ describe("PUT (unit tests)", () => {
         // Arrange
         const invalidRequestBody = {
             ...happyPathRequest,
-            createdBy: ourUserId,
             leagueStatus: "maybe-active",
             wikiPageUrl: `https://en.wikipedia.org/wiki/${happyPathRequest.wikiPageName}`,
             wikiApiUrl: `https://en.wikipedia.org/w/api.php?action=parse&format=json&page=${happyPathRequest.wikiPageName}`
@@ -941,5 +1013,64 @@ describe("PUT (unit tests)", () => {
         const rawBody = await response.body.getReader().read();
         const bodyString = new TextDecoder().decode(rawBody.value);
         expect(bodyString).toContain("leagueStatus");
+    });
+
+    it("should use wikiPageUrl and wikiApiUrl from request body when updating", async () => {
+        // Arrange
+        const customWikiPageUrl = "https://en.wikipedia.org/wiki/Custom_Page";
+        const customWikiApiUrl = "https://en.wikipedia.org/w/api.php?action=parse&format=json&page=Custom_Page";
+        const request = {
+            cookies: {
+                get: jest.fn().mockImplementation(()=> {
+                    return "testToken"
+                })
+            },
+            json: jest.fn().mockImplementation(async () => {
+                return {
+                    ...happyPathRequest,
+                    wikiPageUrl: customWikiPageUrl,
+                    wikiApiUrl: customWikiApiUrl
+                };
+            })
+        };
+
+        // Act
+        const response = await PUT(request);
+
+        // Assert
+        expect(response).not.toBeNull();
+        expect(response.status).toEqual(200);
+        expect(writeLeagueConfigurationData).toHaveBeenCalledWith(
+            expect.anything(),
+            expect.objectContaining({
+                wikiPageUrl: customWikiPageUrl,
+                wikiApiUrl: customWikiApiUrl
+            })
+        );
+    });
+
+    it("should call getAllKeys with correct league key pattern", async () => {
+        // Arrange
+        const request = {
+            cookies: {
+                get: jest.fn().mockImplementation(()=> {
+                    return "testToken"
+                })
+            },
+            json: jest.fn().mockImplementation(async () => {
+                return {
+                    ...happyPathRequest,
+                    wikiPageUrl: `https://en.wikipedia.org/wiki/${happyPathRequest.wikiPageName}`,
+                    wikiApiUrl: `https://en.wikipedia.org/w/api.php?action=parse&format=json&page=${happyPathRequest.wikiPageName}`
+                };
+            })
+        };
+
+        // Act
+        const response = await PUT(request);
+
+        // Assert
+        expect(response).not.toBeNull();
+        expect(getAllKeys).toHaveBeenCalledWith(`league_configuration:*:${happyPathRequest.leagueKey}`);
     });
 });

--- a/__tests__/api/league/route.js
+++ b/__tests__/api/league/route.js
@@ -925,7 +925,7 @@ describe("PUT (unit tests)", () => {
         expect(response.status).toEqual(404);
     });
 
-    it("should return a 500 when multiple league configurations found", async () => {
+    it("should return a 409 when multiple league configurations found", async () => {
         // Arrange
         getAllKeys.mockImplementation(() => {
             return Promise.resolve([
@@ -953,7 +953,7 @@ describe("PUT (unit tests)", () => {
 
         // Assert
         expect(response).not.toBeNull();
-        expect(response.status).toEqual(500);
+        expect(response.status).toEqual(409);
     });
 
     it("should return a 403 when PUT userId does not match createdBy from database", async () => {

--- a/__tests__/api/league/route.js
+++ b/__tests__/api/league/route.js
@@ -6,7 +6,7 @@ jest.mock("google-auth-library");
 jest.mock("../../../app/dataSources/dbFetch");
 import * as sessionModule from "../../../app/api/session/session";
 import { OAuth2Client } from "google-auth-library";
-import { writeLeagueConfigurationData, getUser, getAllKeys, getLeagueConfigurationData } from "@/app/dataSources/dbFetch";
+import { writeLeagueConfigurationData, getUser, getAllKeys, getLeagueConfigurationData, deleteLeagueConfigurationData } from "@/app/dataSources/dbFetch";
 import { POST, PUT } from "@/app/api/league/route.ts";
 
 let testAuthData = {}
@@ -30,6 +30,10 @@ OAuth2Client.mockImplementation(() => {
 
 writeLeagueConfigurationData.mockImplementation(() => {
     return () => { }
+});
+
+deleteLeagueConfigurationData.mockImplementation(() => {
+    return Promise.resolve();
 });
 
 const ourUserId = "ourUserId67C20C65-064D-444C-9AC0-DB5E14A38863";
@@ -859,7 +863,8 @@ describe("PUT (unit tests)", () => {
 
         getLeagueConfigurationData.mockImplementation(() => {
             return Promise.resolve({
-                createdBy: ourUserId
+                createdBy: ourUserId,
+                leagueStatus: happyPathRequest.leagueStatus
             });
         });
     });
@@ -875,6 +880,7 @@ describe("PUT (unit tests)", () => {
         getLeagueConfigurationData.mockImplementation(() => {
             return Promise.resolve({
                 createdBy: ourUserId,
+                leagueStatus: happyPathRequest.leagueStatus,
                 wikiPageUrl: dbWikiPageUrl,
                 wikiApiUrl: dbWikiApiUrl,
                 castPhrase: dbCastPhrase,
@@ -1024,6 +1030,7 @@ describe("PUT (unit tests)", () => {
         getLeagueConfigurationData.mockImplementation(() => {
             return Promise.resolve({
                 createdBy: ourUserId,
+                leagueStatus: happyPathRequest.leagueStatus,
                 wikiPageUrl: dbWikiPageUrl,
                 wikiApiUrl: dbWikiApiUrl,
                 castPhrase: "Cast",
@@ -1067,6 +1074,7 @@ describe("PUT (unit tests)", () => {
         getLeagueConfigurationData.mockImplementation(() => {
             return Promise.resolve({
                 createdBy: ourUserId,
+                leagueStatus: happyPathRequest.leagueStatus,
                 wikiPageUrl: "https://en.wikipedia.org/wiki/Page",
                 wikiApiUrl: "https://en.wikipedia.org/w/api.php",
                 castPhrase: dbCastPhrase,
@@ -1132,6 +1140,7 @@ describe("PUT (unit tests)", () => {
         getLeagueConfigurationData.mockImplementation(() => {
             return Promise.resolve({
                 createdBy: ourUserId,
+                leagueStatus: happyPathRequest.leagueStatus,
                 wikiPageUrl: "https://en.wikipedia.org/wiki/Page",
                 wikiApiUrl: "https://en.wikipedia.org/w/api.php",
                 castPhrase: "Cast",
@@ -1161,5 +1170,92 @@ describe("PUT (unit tests)", () => {
             `league_configuration:${happyPathRequest.leagueStatus}:${dbContestantLeagueDataKeyPrefix}`,
             expect.anything()
         );
+    });
+
+    it("should delete the preexisting configuration when leagueStatus changes", async () => {
+        // Arrange
+        const preexistingLeagueConfigurationKey = `league_configuration:inactive:${happyPathRequest.leagueKey}`;
+        const dbContestantLeagueDataKeyPrefix = `${happyPathRequest.leagueKey}:*`;
+        
+        getAllKeys.mockImplementation(() => {
+            return Promise.resolve([preexistingLeagueConfigurationKey]);
+        });
+
+        getLeagueConfigurationData.mockImplementation(() => {
+            return Promise.resolve({
+                createdBy: ourUserId,
+                leagueStatus: "inactive",
+                wikiPageUrl: "https://en.wikipedia.org/wiki/Page",
+                wikiApiUrl: "https://en.wikipedia.org/w/api.php",
+                castPhrase: "Cast",
+                competitingEntityName: "person",
+                contestantLeagueDataKeyPrefix: dbContestantLeagueDataKeyPrefix
+            });
+        });
+
+        const request = {
+            cookies: {
+                get: jest.fn().mockImplementation(()=> {
+                    return "testToken"
+                })
+            },
+            json: jest.fn().mockImplementation(async () => {
+                return {
+                    ...happyPathRequest,
+                    leagueStatus: "active"
+                };
+            })
+        };
+
+        // Act
+        const response = await PUT(request);
+
+        // Assert
+        expect(response).not.toBeNull();
+        expect(response.status).toEqual(200);
+        expect(deleteLeagueConfigurationData).toHaveBeenCalledWith(preexistingLeagueConfigurationKey);
+    });
+
+    it("should not delete the preexisting configuration when leagueStatus does not change", async () => {
+        // Arrange
+        const preexistingLeagueConfigurationKey = `league_configuration:active:${happyPathRequest.leagueKey}`;
+        const dbContestantLeagueDataKeyPrefix = `${happyPathRequest.leagueKey}:*`;
+        
+        getAllKeys.mockImplementation(() => {
+            return Promise.resolve([preexistingLeagueConfigurationKey]);
+        });
+
+        getLeagueConfigurationData.mockImplementation(() => {
+            return Promise.resolve({
+                createdBy: ourUserId,
+                leagueStatus: "active",
+                wikiPageUrl: "https://en.wikipedia.org/wiki/Page",
+                wikiApiUrl: "https://en.wikipedia.org/w/api.php",
+                castPhrase: "Cast",
+                competitingEntityName: "person",
+                contestantLeagueDataKeyPrefix: dbContestantLeagueDataKeyPrefix
+            });
+        });
+
+        deleteLeagueConfigurationData.mockClear();
+
+        const request = {
+            cookies: {
+                get: jest.fn().mockImplementation(()=> {
+                    return "testToken"
+                })
+            },
+            json: jest.fn().mockImplementation(async () => {
+                return happyPathRequest;
+            })
+        };
+
+        // Act
+        const response = await PUT(request);
+
+        // Assert
+        expect(response).not.toBeNull();
+        expect(response.status).toEqual(200);
+        expect(deleteLeagueConfigurationData).not.toHaveBeenCalled();
     });
 });

--- a/__tests__/api/league/route.js
+++ b/__tests__/api/league/route.js
@@ -7,7 +7,7 @@ jest.mock("../../../app/dataSources/dbFetch");
 import * as sessionModule from "../../../app/api/session/session";
 import { OAuth2Client } from "google-auth-library";
 import { writeLeagueConfigurationData, getUser } from "@/app/dataSources/dbFetch";
-import { POST } from "@/app/api/league/route.ts";
+import { POST, PUT } from "@/app/api/league/route.ts";
 
 let testAuthData = {}
 let happyPathRequest = {}
@@ -848,5 +848,98 @@ describe("POST (unit tests)", () => {
             expect.objectContaining({
                 "createdBy": ourUserId
             }));
+    });
+});
+
+describe("PUT (unit tests)", () => {
+    it("should return 200 when PUT conditions met", async () => {
+        // Arrange
+        const request = {
+            cookies: {
+                get: jest.fn().mockImplementation(()=> {
+                    return "testToken"
+                })
+            },
+            json: jest.fn().mockImplementation(async () => {
+                return {
+                    ...happyPathRequest,
+                    createdBy: ourUserId,
+                    wikiPageUrl: `https://en.wikipedia.org/wiki/${happyPathRequest.wikiPageName}`,
+                    wikiApiUrl: `https://en.wikipedia.org/w/api.php?action=parse&format=json&page=${happyPathRequest.wikiPageName}`
+                };
+            })
+        };
+
+        // Act
+        const response = await PUT(request);
+
+        // Assert
+        expect(response).not.toBeNull();
+        expect(response.status).toEqual(200);
+        expect(request.json).toHaveBeenCalledTimes(1);
+        expect(writeLeagueConfigurationData).toHaveBeenCalledTimes(1);
+        expect(writeLeagueConfigurationData).toHaveBeenCalledWith(
+            `league_configuration:${happyPathRequest.leagueStatus}:${happyPathRequest.leagueKey}`,
+            expect.objectContaining({
+                googleSheetUrl: happyPathRequest.googleSheetUrl,
+                createdBy: ourUserId
+            })
+        );
+    });
+
+    it("should return a 403 when PUT createdBy does not match session user", async () => {
+        // Arrange
+        const request = {
+            cookies: {
+                get: jest.fn().mockImplementation(()=> {
+                    return "testToken"
+                })
+            },
+            json: jest.fn().mockImplementation(async () => {
+                return {
+                    ...happyPathRequest,
+                    createdBy: "differentUser",
+                    wikiPageUrl: `https://en.wikipedia.org/wiki/${happyPathRequest.wikiPageName}`,
+                    wikiApiUrl: `https://en.wikipedia.org/w/api.php?action=parse&format=json&page=${happyPathRequest.wikiPageName}`
+                };
+            })
+        };
+
+        // Act
+        const response = await PUT(request);
+
+        // Assert
+        expect(response).not.toBeNull();
+        expect(response.status).toEqual(403);
+    });
+
+    it("should return a 400 when PUT has invalid leagueStatus", async () => {
+        // Arrange
+        const invalidRequestBody = {
+            ...happyPathRequest,
+            createdBy: ourUserId,
+            leagueStatus: "maybe-active",
+            wikiPageUrl: `https://en.wikipedia.org/wiki/${happyPathRequest.wikiPageName}`,
+            wikiApiUrl: `https://en.wikipedia.org/w/api.php?action=parse&format=json&page=${happyPathRequest.wikiPageName}`
+        };
+        const request = {
+            cookies: {
+                get: jest.fn().mockImplementation(()=> {
+                    return "testToken"
+                })
+            },
+            json: jest.fn().mockImplementation(async () => invalidRequestBody)
+        };
+
+        // Act
+        const response = await PUT(request);
+
+        // Assert
+        expect(response).not.toBeNull();
+        expect(response.status).toEqual(400);
+
+        const rawBody = await response.body.getReader().read();
+        const bodyString = new TextDecoder().decode(rawBody.value);
+        expect(bodyString).toContain("leagueStatus");
     });
 });

--- a/__tests__/api/league/route.js
+++ b/__tests__/api/league/route.js
@@ -11,6 +11,7 @@ import { POST, PUT } from "@/app/api/league/route.ts";
 
 let testAuthData = {}
 let happyPathRequest = {}
+const leagueConfigKey = "some_show_name:and_season_1";
 
 const getPayloadMock = jest.fn().mockImplementation(()=> {
     return testAuthData
@@ -60,16 +61,6 @@ beforeEach(() => {
         family_name: "TestLastName"
     };
 
-    happyPathRequest = {
-        token: "testToken",
-        wikiPageName: "someName",
-        googleSheetUrl: "https://some.url",
-        leagueStatus: "active",
-        wikiSectionHeader: "Show Contestants",
-        contestantType: "team",
-        leagueKey: "some_show_name:and_season_1"
-    };
-
     getUser.mockImplementation(() => {
         return Promise.resolve({
             role: "showAdmin"
@@ -83,6 +74,22 @@ afterEach(() => {
 });
 
 describe("POST (unit tests)", () => {
+    beforeEach(()=> {
+        happyPathRequest = {
+            token: "testToken",
+            wikiPageName: "someName",
+            googleSheetUrl: "https://some.url",
+            leagueStatus: "active",
+            wikiSectionHeader: "Show Contestants",
+            contestantType: "team",
+            leagueKey: leagueConfigKey
+        };
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
     it("should return 200 when conditions met", async () => {
         // Arrange
         const request = {
@@ -857,16 +864,27 @@ describe("POST (unit tests)", () => {
 
 describe("PUT (unit tests)", () => {
     beforeEach(() => {
+        happyPathRequest = {
+            createdBy: ourUserId,
+            leagueStatus: "active",
+            leagueKey: leagueConfigKey
+        };
+
+        getUser.mockImplementation(() => {
+            return Promise.resolve({
+                role: "showAdmin"
+            });
+        });
+
         getAllKeys.mockImplementation(() => {
             return Promise.resolve([`league_configuration:${happyPathRequest.leagueStatus}:${happyPathRequest.leagueKey}`]);
         });
 
-        getLeagueConfigurationData.mockImplementation(() => {
-            return Promise.resolve({
-                createdBy: ourUserId,
-                leagueStatus: happyPathRequest.leagueStatus
-            });
-        });
+        
+    });
+
+    afterEach(()=> {
+        jest.clearAllMocks();
     });
 
     it("should return 200 when PUT conditions met", async () => {
@@ -911,7 +929,7 @@ describe("PUT (unit tests)", () => {
         expect(writeLeagueConfigurationData).toHaveBeenCalledWith(
             `league_configuration:${happyPathRequest.leagueStatus}:${dbContestantLeagueDataKeyPrefix}`,
             expect.objectContaining({
-                googleSheetUrl: happyPathRequest.googleSheetUrl,
+                createdBy: happyPathRequest.createdBy,
                 leagueStatus: happyPathRequest.leagueStatus
             })
         );
@@ -1021,11 +1039,13 @@ describe("PUT (unit tests)", () => {
         expect(bodyString).toContain("leagueStatus");
     });
 
-    it("should use wikiPageUrl and wikiApiUrl from database when updating", async () => {
+    it("should use wikiPageUrl, wikiApiUrl, castPhrase, and competitingEntityName from database when updating", async () => {
         // Arrange
         const dbWikiPageUrl = "https://en.wikipedia.org/wiki/Database_Page";
         const dbWikiApiUrl = "https://en.wikipedia.org/w/api.php?action=parse&format=json&page=Database_Page";
         const dbContestantLeagueDataKeyPrefix = `${happyPathRequest.leagueKey}:*`;
+        const dbCastPhrase = "Original Cast";
+        const dbCompetitingEntityName = "person";
         
         getLeagueConfigurationData.mockImplementation(() => {
             return Promise.resolve({
@@ -1033,8 +1053,8 @@ describe("PUT (unit tests)", () => {
                 leagueStatus: happyPathRequest.leagueStatus,
                 wikiPageUrl: dbWikiPageUrl,
                 wikiApiUrl: dbWikiApiUrl,
-                castPhrase: "Cast",
-                competitingEntityName: "person",
+                castPhrase: dbCastPhrase,
+                competitingEntityName: dbCompetitingEntityName,
                 contestantLeagueDataKeyPrefix: dbContestantLeagueDataKeyPrefix
             });
         });
@@ -1060,53 +1080,7 @@ describe("PUT (unit tests)", () => {
             expect.anything(),
             expect.objectContaining({
                 wikiPageUrl: dbWikiPageUrl,
-                wikiApiUrl: dbWikiApiUrl
-            })
-        );
-    });
-
-    it("should use castPhrase and competitingEntityName from database when updating", async () => {
-        // Arrange
-        const dbCastPhrase = "Original Cast";
-        const dbCompetitingEntityName = "person";
-        const dbContestantLeagueDataKeyPrefix = `${happyPathRequest.leagueKey}:*`;
-        
-        getLeagueConfigurationData.mockImplementation(() => {
-            return Promise.resolve({
-                createdBy: ourUserId,
-                leagueStatus: happyPathRequest.leagueStatus,
-                wikiPageUrl: "https://en.wikipedia.org/wiki/Page",
-                wikiApiUrl: "https://en.wikipedia.org/w/api.php",
-                castPhrase: dbCastPhrase,
-                competitingEntityName: dbCompetitingEntityName,
-                contestantLeagueDataKeyPrefix: dbContestantLeagueDataKeyPrefix
-            });
-        });
-
-        const request = {
-            cookies: {
-                get: jest.fn().mockImplementation(()=> {
-                    return "testToken"
-                })
-            },
-            json: jest.fn().mockImplementation(async () => {
-                return {
-                    ...happyPathRequest,
-                    castPhrase: "Different Cast",
-                    contestantType: "team"
-                };
-            })
-        };
-
-        // Act
-        const response = await PUT(request);
-
-        // Assert
-        expect(response).not.toBeNull();
-        expect(response.status).toEqual(200);
-        expect(writeLeagueConfigurationData).toHaveBeenCalledWith(
-            expect.anything(),
-            expect.objectContaining({
+                wikiApiUrl: dbWikiApiUrl,
                 castPhrase: dbCastPhrase,
                 competitingEntityName: dbCompetitingEntityName
             })

--- a/__tests__/api/league/route.js
+++ b/__tests__/api/league/route.js
@@ -6,7 +6,7 @@ jest.mock("google-auth-library");
 jest.mock("../../../app/dataSources/dbFetch");
 import * as sessionModule from "../../../app/api/session/session";
 import { OAuth2Client } from "google-auth-library";
-import { writeLeagueConfigurationData, getUser, getAllKeys, getLeagueConfigurationData, deleteLeagueConfigurationData } from "@/app/dataSources/dbFetch";
+import { writeLeagueConfigurationData, getUser, getAllKeys, getLeagueConfigurationData, updateLeagueConfigurationData } from "@/app/dataSources/dbFetch";
 import { POST, PUT } from "@/app/api/league/route.ts";
 
 let testAuthData = {}
@@ -33,7 +33,7 @@ writeLeagueConfigurationData.mockImplementation(() => {
     return () => { }
 });
 
-deleteLeagueConfigurationData.mockImplementation(() => {
+updateLeagueConfigurationData.mockImplementation(() => {
     return Promise.resolve();
 });
 
@@ -870,17 +870,9 @@ describe("PUT (unit tests)", () => {
             leagueKey: leagueConfigKey
         };
 
-        getUser.mockImplementation(() => {
-            return Promise.resolve({
-                role: "showAdmin"
-            });
-        });
-
         getAllKeys.mockImplementation(() => {
             return Promise.resolve([`league_configuration:${happyPathRequest.leagueStatus}:${happyPathRequest.leagueKey}`]);
         });
-
-        
     });
 
     afterEach(()=> {
@@ -925,9 +917,9 @@ describe("PUT (unit tests)", () => {
         expect(response).not.toBeNull();
         expect(response.status).toEqual(200);
         expect(request.json).toHaveBeenCalledTimes(1);
-        expect(writeLeagueConfigurationData).toHaveBeenCalledTimes(1);
-        expect(writeLeagueConfigurationData).toHaveBeenCalledWith(
-            `league_configuration:${happyPathRequest.leagueStatus}:${dbContestantLeagueDataKeyPrefix}`,
+        expect(updateLeagueConfigurationData).toHaveBeenCalledTimes(1);
+        expect(updateLeagueConfigurationData).toHaveBeenCalledWith(
+            happyPathRequest.leagueKey,
             expect.objectContaining({
                 createdBy: happyPathRequest.createdBy,
                 leagueStatus: happyPathRequest.leagueStatus
@@ -1076,7 +1068,7 @@ describe("PUT (unit tests)", () => {
         // Assert
         expect(response).not.toBeNull();
         expect(response.status).toEqual(200);
-        expect(writeLeagueConfigurationData).toHaveBeenCalledWith(
+        expect(updateLeagueConfigurationData).toHaveBeenCalledWith(
             expect.anything(),
             expect.objectContaining({
                 wikiPageUrl: dbWikiPageUrl,
@@ -1108,9 +1100,10 @@ describe("PUT (unit tests)", () => {
         expect(getAllKeys).toHaveBeenCalledWith(`league_configuration:*:${happyPathRequest.leagueKey}`);
     });
 
-    it("should construct the write key using database contestantLeagueDataKeyPrefix", async () => {
+    it("should construct the update key using database contestantLeagueDataKeyPrefix", async () => {
         // Arrange
-        const dbContestantLeagueDataKeyPrefix = `${happyPathRequest.leagueKey}:*`;
+        const dbContestantLeagueDataKeyPrefix = "tvshowTestKey";
+
         getLeagueConfigurationData.mockImplementation(() => {
             return Promise.resolve({
                 createdBy: ourUserId,
@@ -1119,7 +1112,7 @@ describe("PUT (unit tests)", () => {
                 wikiApiUrl: "https://en.wikipedia.org/w/api.php",
                 castPhrase: "Cast",
                 competitingEntityName: "person",
-                contestantLeagueDataKeyPrefix: dbContestantLeagueDataKeyPrefix
+                contestantLeagueDataKeyPrefix: `${dbContestantLeagueDataKeyPrefix}:*`
             });
         });
 
@@ -1133,103 +1126,23 @@ describe("PUT (unit tests)", () => {
                 return happyPathRequest;
             })
         };
-
+        
         // Act
         const response = await PUT(request);
+        console.log(getAllKeys.mock.results[0].value);
 
         // Assert
         expect(response).not.toBeNull();
         expect(response.status).toEqual(200);
-        expect(writeLeagueConfigurationData).toHaveBeenCalledWith(
-            `league_configuration:${happyPathRequest.leagueStatus}:${dbContestantLeagueDataKeyPrefix}`,
+        expect(updateLeagueConfigurationData).not.toHaveBeenCalledWith(
+            `${happyPathRequest.leagueStatus}:${dbContestantLeagueDataKeyPrefix}`,
             expect.anything()
         );
-    });
-
-    it("should delete the preexisting configuration when leagueStatus changes", async () => {
-        // Arrange
-        const preexistingLeagueConfigurationKey = `league_configuration:inactive:${happyPathRequest.leagueKey}`;
-        const dbContestantLeagueDataKeyPrefix = `${happyPathRequest.leagueKey}:*`;
-        
-        getAllKeys.mockImplementation(() => {
-            return Promise.resolve([preexistingLeagueConfigurationKey]);
-        });
-
-        getLeagueConfigurationData.mockImplementation(() => {
-            return Promise.resolve({
-                createdBy: ourUserId,
-                leagueStatus: "inactive",
-                wikiPageUrl: "https://en.wikipedia.org/wiki/Page",
-                wikiApiUrl: "https://en.wikipedia.org/w/api.php",
-                castPhrase: "Cast",
-                competitingEntityName: "person",
-                contestantLeagueDataKeyPrefix: dbContestantLeagueDataKeyPrefix
-            });
-        });
-
-        const request = {
-            cookies: {
-                get: jest.fn().mockImplementation(()=> {
-                    return "testToken"
-                })
-            },
-            json: jest.fn().mockImplementation(async () => {
-                return {
-                    ...happyPathRequest,
-                    leagueStatus: "active"
-                };
-            })
-        };
-
-        // Act
-        const response = await PUT(request);
-
-        // Assert
-        expect(response).not.toBeNull();
-        expect(response.status).toEqual(200);
-        expect(deleteLeagueConfigurationData).toHaveBeenCalledWith(preexistingLeagueConfigurationKey);
-    });
-
-    it("should not delete the preexisting configuration when leagueStatus does not change", async () => {
-        // Arrange
-        const preexistingLeagueConfigurationKey = `league_configuration:active:${happyPathRequest.leagueKey}`;
-        const dbContestantLeagueDataKeyPrefix = `${happyPathRequest.leagueKey}:*`;
-        
-        getAllKeys.mockImplementation(() => {
-            return Promise.resolve([preexistingLeagueConfigurationKey]);
-        });
-
-        getLeagueConfigurationData.mockImplementation(() => {
-            return Promise.resolve({
-                createdBy: ourUserId,
-                leagueStatus: "active",
-                wikiPageUrl: "https://en.wikipedia.org/wiki/Page",
-                wikiApiUrl: "https://en.wikipedia.org/w/api.php",
-                castPhrase: "Cast",
-                competitingEntityName: "person",
-                contestantLeagueDataKeyPrefix: dbContestantLeagueDataKeyPrefix
-            });
-        });
-
-        deleteLeagueConfigurationData.mockClear();
-
-        const request = {
-            cookies: {
-                get: jest.fn().mockImplementation(()=> {
-                    return "testToken"
-                })
-            },
-            json: jest.fn().mockImplementation(async () => {
-                return happyPathRequest;
-            })
-        };
-
-        // Act
-        const response = await PUT(request);
-
-        // Assert
-        expect(response).not.toBeNull();
-        expect(response.status).toEqual(200);
-        expect(deleteLeagueConfigurationData).not.toHaveBeenCalled();
+        expect(getAllKeys.mock.calls[0][0]).toContain(`league_configuration:*:${happyPathRequest.leagueKey}`);
+        expect(getLeagueConfigurationData).toHaveBeenCalledWith(`league_configuration:${happyPathRequest.leagueStatus}:${happyPathRequest.leagueKey}`);
+        expect(updateLeagueConfigurationData).toHaveBeenCalledWith(
+            happyPathRequest.leagueKey,
+            expect.anything()
+        );
     });
 });

--- a/app/api/league/route.ts
+++ b/app/api/league/route.ts
@@ -85,13 +85,15 @@ export async function POST(request: NextRequest) {
 }
 
 const LeagueConfigUpdate = z.object({
-    googleSheetUrl: validationPattern.googleSheetUrl.zod,
-    leagueStatus: validationPattern.leagueStatus.zod
+    createdBy: validationPattern.createdBy.zod,
+    leagueStatus: validationPattern.leagueStatus.zod,
+    leagueKey: validationPattern.leagueKey.zod
 });
 
 export async function PUT (request: NextRequest) {
     // check auth
     const body = await request.json();
+    console.log(body);
     const sessionCookie = request.cookies.get("session");
     if(!sessionCookie){
         return NextResponse.json({"error": unauthenticatedErrorMessage}, {status: 401});
@@ -108,8 +110,7 @@ export async function PUT (request: NextRequest) {
     // validate/sanitize input
     try {
         LeagueConfigUpdate.parse(body);
-    }
-    catch(error: unknown){
+    } catch(error: unknown){
         if (error instanceof z.ZodError) {
             const firstIssue = error.issues[0];
             return NextResponse.json(

--- a/app/api/league/route.ts
+++ b/app/api/league/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import validationPattern from "@/app/dataSources/validationPatterns";
 import * as z from "zod/v4";
 import { decrypt } from "@/app/api/session/session";
-import { getUser, getAllKeys, getLeagueConfigurationData, writeLeagueConfigurationData } from "@/app/dataSources/dbFetch";
+import { getUser, getAllKeys, getLeagueConfigurationData, writeLeagueConfigurationData, deleteLeagueConfigurationData } from "@/app/dataSources/dbFetch";
 import { unauthenticatedErrorMessage } from "@/app/api/constants/errors";
 
 interface decryptionPayload {
@@ -127,11 +127,15 @@ export async function PUT (request: NextRequest) {
         return NextResponse.json({"error": "multiple league configurations found for that league key, please contact support"}, {status: 409});
     }
 
-    const leagueConfigurationKey = leagueConfigurationKeyArray[0];
-    const leagueConfigurationData = await getLeagueConfigurationData(leagueConfigurationKey);
+    const preexistingLeagueConfigurationKey = leagueConfigurationKeyArray[0];
+    const leagueConfigurationData = await getLeagueConfigurationData(preexistingLeagueConfigurationKey);
     const isUserDenied = userId !== leagueConfigurationData.createdBy;
     if(isUserDenied){
         return NextResponse.json({"error": "you are not authorized to perform that action"}, {status: 403});
+    }
+
+    if(leagueConfigurationData.leagueStatus !== body.leagueStatus){
+        await deleteLeagueConfigurationData(preexistingLeagueConfigurationKey);
     }
 
     // insert into db

--- a/app/api/league/route.ts
+++ b/app/api/league/route.ts
@@ -93,7 +93,6 @@ const LeagueConfigUpdate = z.object({
 export async function PUT (request: NextRequest) {
     // check auth
     const body = await request.json();
-    console.log(body);
     const sessionCookie = request.cookies.get("session");
     if(!sessionCookie){
         return NextResponse.json({"error": unauthenticatedErrorMessage}, {status: 401});

--- a/app/api/league/route.ts
+++ b/app/api/league/route.ts
@@ -119,7 +119,7 @@ export async function PUT (request: NextRequest) {
     if(leagueConfigurationKeyArray.length === 0){
         return NextResponse.json({"error": "no league configuration found for that league key"}, {status: 404});
     } else if (leagueConfigurationKeyArray.length > 1){
-        return NextResponse.json({"error": "multiple league configurations found for that league key, please contact support"}, {status: 500});
+        return NextResponse.json({"error": "multiple league configurations found for that league key, please contact support"}, {status: 409});
     } else {
         const leagueConfigurationKey = leagueConfigurationKeyArray[0];
         const leagueConfigurationData = await getLeagueConfigurationData(leagueConfigurationKey);

--- a/app/api/league/route.ts
+++ b/app/api/league/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import validationPattern from "@/app/dataSources/validationPatterns";
 import * as z from "zod/v4";
 import { decrypt } from "@/app/api/session/session";
-import { getUser, writeLeagueConfigurationData } from "@/app/dataSources/dbFetch";
+import { getUser, getAllKeys, getLeagueConfigurationData, writeLeagueConfigurationData } from "@/app/dataSources/dbFetch";
 import { unauthenticatedErrorMessage } from "@/app/api/constants/errors";
 
 interface decryptionPayload {
@@ -97,10 +97,18 @@ export async function PUT (request: NextRequest) {
         if (invalidUserId || invalidUserSub ) {
             return NextResponse.json({"error": unauthenticatedErrorMessage}, {status: 401});
         }
-        
-        const isUserDenied = userId !== body.createdBy;
-        if(isUserDenied){
-            return NextResponse.json({"error": "you are not authorized to perform that action"}, {status: 403});
+        const leagueConfigurationKeyArray = await getAllKeys(`league_configuration:*:${body.leagueKey}`);
+        if(leagueConfigurationKeyArray.length === 0){
+            return NextResponse.json({"error": "no league configuration found for that league key"}, {status: 404});
+        } else if (leagueConfigurationKeyArray.length > 1){
+            return NextResponse.json({"error": "multiple league configurations found for that league key, please contact support"}, {status: 500});
+        } else {
+            const leagueConfigurationKey = leagueConfigurationKeyArray[0];
+            const leagueConfigurationData = await getLeagueConfigurationData(leagueConfigurationKey);
+            const isUserDenied = userId !== leagueConfigurationData.createdBy;
+            if(isUserDenied){
+                return NextResponse.json({"error": "you are not authorized to perform that action"}, {status: 403});
+            }
         }
     } else {
         return NextResponse.json({"error": unauthenticatedErrorMessage}, {status: 401});

--- a/app/api/league/route.ts
+++ b/app/api/league/route.ts
@@ -84,6 +84,11 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({"message": "posted"});
 }
 
+const LeagueConfigUpdate = z.object({
+    googleSheetUrl: validationPattern.googleSheetUrl.zod,
+    leagueStatus: validationPattern.leagueStatus.zod
+});
+
 export async function PUT (request: NextRequest) {
     // check auth
     const body = await request.json();
@@ -102,7 +107,7 @@ export async function PUT (request: NextRequest) {
 
     // validate/sanitize input
     try {
-        LeagueConfig.parse(body);
+        LeagueConfigUpdate.parse(body);
     }
     catch(error: unknown){
         if (error instanceof z.ZodError) {
@@ -121,7 +126,7 @@ export async function PUT (request: NextRequest) {
     } else if (leagueConfigurationKeyArray.length > 1){
         return NextResponse.json({"error": "multiple league configurations found for that league key, please contact support"}, {status: 409});
     }
-    
+
     const leagueConfigurationKey = leagueConfigurationKeyArray[0];
     const leagueConfigurationData = await getLeagueConfigurationData(leagueConfigurationKey);
     const isUserDenied = userId !== leagueConfigurationData.createdBy;
@@ -130,17 +135,17 @@ export async function PUT (request: NextRequest) {
     }
 
     // insert into db
-    const leagueConfigKey = `league_configuration:${body.leagueStatus}:${body.leagueKey}`;
+    const leagueConfigKey = `league_configuration:${body.leagueStatus}:${leagueConfigurationData.contestantLeagueDataKeyPrefix}`;
     const leagueConfig = {
-        wikiPageUrl: body.wikiPageUrl,
-        wikiApiUrl: body.wikiApiUrl,
+        wikiPageUrl: leagueConfigurationData.wikiPageUrl,
+        wikiApiUrl: leagueConfigurationData.wikiApiUrl,
         googleSheetUrl: body.googleSheetUrl,
         leagueStatus: body.leagueStatus,
-        castPhrase: body.wikiSectionHeader,
+        castPhrase: leagueConfigurationData.castPhrase,
         preGoogleSheetsLinkText: "This season's contestant data has been sourced from",
         postGoogleSheetsLinkText: "which was populated using a google form.",
-        competitingEntityName: body.contestantType,
-        contestantLeagueDataKeyPrefix: `${body.leagueKey}:*`,
+        competitingEntityName: leagueConfigurationData.competitingEntityName,
+        contestantLeagueDataKeyPrefix: leagueConfigurationData.contestantLeagueDataKeyPrefix,
         createdBy: userId
     };
 

--- a/app/api/league/route.ts
+++ b/app/api/league/route.ts
@@ -88,29 +88,15 @@ export async function PUT (request: NextRequest) {
     // check auth
     const body = await request.json();
     const sessionCookie = request.cookies.get("session");
-    let userId: string | undefined;
-    if(sessionCookie){
-        const decryptedSessionCookie = await decrypt(sessionCookie?.value) as decryptionPayload;
-        userId = decryptedSessionCookie?.sub;
-        const invalidUserId = !userId;
-        const invalidUserSub = Object.keys(decryptedSessionCookie).length !== 3;
-        if (invalidUserId || invalidUserSub ) {
-            return NextResponse.json({"error": unauthenticatedErrorMessage}, {status: 401});
-        }
-        const leagueConfigurationKeyArray = await getAllKeys(`league_configuration:*:${body.leagueKey}`);
-        if(leagueConfigurationKeyArray.length === 0){
-            return NextResponse.json({"error": "no league configuration found for that league key"}, {status: 404});
-        } else if (leagueConfigurationKeyArray.length > 1){
-            return NextResponse.json({"error": "multiple league configurations found for that league key, please contact support"}, {status: 500});
-        } else {
-            const leagueConfigurationKey = leagueConfigurationKeyArray[0];
-            const leagueConfigurationData = await getLeagueConfigurationData(leagueConfigurationKey);
-            const isUserDenied = userId !== leagueConfigurationData.createdBy;
-            if(isUserDenied){
-                return NextResponse.json({"error": "you are not authorized to perform that action"}, {status: 403});
-            }
-        }
-    } else {
+    if(!sessionCookie){
+        return NextResponse.json({"error": unauthenticatedErrorMessage}, {status: 401});
+    }
+    
+    const decryptedSessionCookie = await decrypt(sessionCookie?.value) as decryptionPayload;
+    const userId = decryptedSessionCookie?.sub;
+    const invalidUserId = !userId;
+    const invalidUserSub = Object.keys(decryptedSessionCookie).length !== 3;
+    if (invalidUserId || invalidUserSub ) {
         return NextResponse.json({"error": unauthenticatedErrorMessage}, {status: 401});
     }
 
@@ -125,6 +111,21 @@ export async function PUT (request: NextRequest) {
                 {"error": `parsing error caught, first one being property: '${String(firstIssue.path[0])}' having issue: '${firstIssue.message}'`},
                 {status: 400}
             );
+        }
+    }
+
+    // check permissions - only allow if user is league owner
+    const leagueConfigurationKeyArray = await getAllKeys(`league_configuration:*:${body.leagueKey}`);
+    if(leagueConfigurationKeyArray.length === 0){
+        return NextResponse.json({"error": "no league configuration found for that league key"}, {status: 404});
+    } else if (leagueConfigurationKeyArray.length > 1){
+        return NextResponse.json({"error": "multiple league configurations found for that league key, please contact support"}, {status: 500});
+    } else {
+        const leagueConfigurationKey = leagueConfigurationKeyArray[0];
+        const leagueConfigurationData = await getLeagueConfigurationData(leagueConfigurationKey);
+        const isUserDenied = userId !== leagueConfigurationData.createdBy;
+        if(isUserDenied){
+            return NextResponse.json({"error": "you are not authorized to perform that action"}, {status: 403});
         }
     }
 

--- a/app/api/league/route.ts
+++ b/app/api/league/route.ts
@@ -120,13 +120,13 @@ export async function PUT (request: NextRequest) {
         return NextResponse.json({"error": "no league configuration found for that league key"}, {status: 404});
     } else if (leagueConfigurationKeyArray.length > 1){
         return NextResponse.json({"error": "multiple league configurations found for that league key, please contact support"}, {status: 409});
-    } else {
-        const leagueConfigurationKey = leagueConfigurationKeyArray[0];
-        const leagueConfigurationData = await getLeagueConfigurationData(leagueConfigurationKey);
-        const isUserDenied = userId !== leagueConfigurationData.createdBy;
-        if(isUserDenied){
-            return NextResponse.json({"error": "you are not authorized to perform that action"}, {status: 403});
-        }
+    }
+    
+    const leagueConfigurationKey = leagueConfigurationKeyArray[0];
+    const leagueConfigurationData = await getLeagueConfigurationData(leagueConfigurationKey);
+    const isUserDenied = userId !== leagueConfigurationData.createdBy;
+    if(isUserDenied){
+        return NextResponse.json({"error": "you are not authorized to perform that action"}, {status: 403});
     }
 
     // insert into db

--- a/app/api/league/route.ts
+++ b/app/api/league/route.ts
@@ -83,3 +83,60 @@ export async function POST(request: NextRequest) {
     // return
     return NextResponse.json({"message": "posted"});
 }
+
+export async function PUT (request: NextRequest) {
+    // check auth
+    const body = await request.json();
+    const sessionCookie = request.cookies.get("session");
+    let userId: string | undefined;
+    if(sessionCookie){
+        const decryptedSessionCookie = await decrypt(sessionCookie?.value) as decryptionPayload;
+        userId = decryptedSessionCookie?.sub;
+        const invalidUserId = !userId;
+        const invalidUserSub = Object.keys(decryptedSessionCookie).length !== 3;
+        if (invalidUserId || invalidUserSub ) {
+            return NextResponse.json({"error": unauthenticatedErrorMessage}, {status: 401});
+        }
+        
+        const isUserDenied = userId !== body.createdBy;
+        if(isUserDenied){
+            return NextResponse.json({"error": "you are not authorized to perform that action"}, {status: 403});
+        }
+    } else {
+        return NextResponse.json({"error": unauthenticatedErrorMessage}, {status: 401});
+    }
+
+    // validate/sanitize input
+    try {
+        LeagueConfig.parse(body);
+    }
+    catch(error: unknown){
+        if (error instanceof z.ZodError) {
+            const firstIssue = error.issues[0];
+            return NextResponse.json(
+                {"error": `parsing error caught, first one being property: '${String(firstIssue.path[0])}' having issue: '${firstIssue.message}'`},
+                {status: 400}
+            );
+        }
+    }
+
+    // insert into db
+    const leagueConfigKey = `league_configuration:${body.leagueStatus}:${body.leagueKey}`;
+    const leagueConfig = {
+        wikiPageUrl: body.wikiPageUrl,
+        wikiApiUrl: body.wikiApiUrl,
+        googleSheetUrl: body.googleSheetUrl,
+        leagueStatus: body.leagueStatus,
+        castPhrase: body.wikiSectionHeader,
+        preGoogleSheetsLinkText: "This season's contestant data has been sourced from",
+        postGoogleSheetsLinkText: "which was populated using a google form.",
+        competitingEntityName: body.contestantType,
+        contestantLeagueDataKeyPrefix: `${body.leagueKey}:*`,
+        createdBy: userId
+    };
+
+    await writeLeagueConfigurationData(leagueConfigKey, leagueConfig);
+
+    // return
+    return NextResponse.json({"message": "posted"});
+}

--- a/app/api/league/route.ts
+++ b/app/api/league/route.ts
@@ -156,5 +156,5 @@ export async function PUT (request: NextRequest) {
     await writeLeagueConfigurationData(leagueConfigKey, leagueConfig);
 
     // return
-    return NextResponse.json({"message": "posted"});
+    return NextResponse.json({"message": "updated"});
 }

--- a/app/api/league/route.ts
+++ b/app/api/league/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import validationPattern from "@/app/dataSources/validationPatterns";
 import * as z from "zod/v4";
 import { decrypt } from "@/app/api/session/session";
-import { getUser, getAllKeys, getLeagueConfigurationData, writeLeagueConfigurationData, deleteLeagueConfigurationData } from "@/app/dataSources/dbFetch";
+import { getUser, getAllKeys, getLeagueConfigurationData, writeLeagueConfigurationData, updateLeagueConfigurationData } from "@/app/dataSources/dbFetch";
 import { unauthenticatedErrorMessage } from "@/app/api/constants/errors";
 
 interface decryptionPayload {
@@ -134,12 +134,7 @@ export async function PUT (request: NextRequest) {
         return NextResponse.json({"error": "you are not authorized to perform that action"}, {status: 403});
     }
 
-    if(leagueConfigurationData.leagueStatus !== body.leagueStatus){
-        await deleteLeagueConfigurationData(preexistingLeagueConfigurationKey);
-    }
-
-    // insert into db
-    const leagueConfigKey = `league_configuration:${body.leagueStatus}:${leagueConfigurationData.contestantLeagueDataKeyPrefix}`;
+    // update in db
     const leagueConfig = {
         wikiPageUrl: leagueConfigurationData.wikiPageUrl,
         wikiApiUrl: leagueConfigurationData.wikiApiUrl,
@@ -152,8 +147,7 @@ export async function PUT (request: NextRequest) {
         contestantLeagueDataKeyPrefix: leagueConfigurationData.contestantLeagueDataKeyPrefix,
         createdBy: userId
     };
-
-    await writeLeagueConfigurationData(leagueConfigKey, leagueConfig);
+    await updateLeagueConfigurationData(body.leagueKey, leagueConfig);
 
     // return
     return NextResponse.json({"message": "updated"});

--- a/app/dataSources/dbFetch.tsx
+++ b/app/dataSources/dbFetch.tsx
@@ -95,6 +95,8 @@ export async function writeLeagueConfigurationData(leagueConfigurationKey: strin
     await redis.json.set(leagueConfigurationKey, "$", leagueConfigString)
 }
 
+
+
 export async function getLeagueConfigurationData(leagueConfigurationKey: string): Promise<ILeagueConfigurationData> {
 
     if (leagueConfigurationKey === undefined) {
@@ -110,6 +112,23 @@ export async function getLeagueConfigurationData(leagueConfigurationKey: string)
         return leagueConfigurationData;
     } else {
         throw new Error("There is no league configuration found for the key provided");
+    }
+}
+
+export async function deleteLeagueConfigurationData(leagueConfigurationKey: string): Promise<void> {
+
+    if (leagueConfigurationKey === undefined) {
+        throw new Error("Unable to deleteLeagueConfigurationData. Provided param 'leagueConfigurationKey' is undefined but must have a value");
+    }
+
+    const redis = new Redis({
+        url: process.env.KV_REST_API_URL,
+        token: process.env.KV_REST_API_TOKEN
+    });
+    try {
+        await redis.del(leagueConfigurationKey);
+    } catch (error) {
+        throw new Error("There was an error deleting the league configuration data for the key provided");
     }
 }
 

--- a/app/dataSources/dbFetch.tsx
+++ b/app/dataSources/dbFetch.tsx
@@ -95,6 +95,30 @@ export async function writeLeagueConfigurationData(leagueConfigurationKey: strin
     await redis.json.set(leagueConfigurationKey, "$", leagueConfigString)
 }
 
+export async function updateLeagueConfigurationData(leagueConfigurationKey: string, leagueConfiguration: ILeagueConfigurationData): Promise<void> {
+    if (leagueConfigurationKey === undefined) {
+        throw new Error("Unable to writeLeagueConfigurationData. Provided param 'leagueConfigurationKey' is undefined but must have a value\"");
+    };
+    if (leagueConfiguration === undefined) {
+        throw new Error("Unable to writeLeagueConfigurationData. Provided param 'leagueConfiguration' is undefined but must have a value");
+    };
+
+    const redis = new Redis({
+        url: process.env.KV_REST_API_URL,
+        token: process.env.KV_REST_API_TOKEN
+    });
+
+    const leagueStatusAndKeyPrefix = leagueConfigurationKey.replace("league_configuration:", "");
+    const index = leagueStatusAndKeyPrefix.indexOf(":");
+    const leagueKeyWithoutStatus = leagueStatusAndKeyPrefix.slice(index + 1);
+    const leagueConfigString = JSON.stringify(leagueConfiguration);
+    const tx = redis.multi();
+    tx.del(leagueConfigurationKey);
+    const newLeagueConfigKey = `league_configuration:${leagueConfiguration.leagueStatus}:${leagueKeyWithoutStatus}`;
+    tx.json.set(newLeagueConfigKey, "$", leagueConfigString);
+    await tx.exec();
+}
+
 
 
 export async function getLeagueConfigurationData(leagueConfigurationKey: string): Promise<ILeagueConfigurationData> {

--- a/app/dataSources/validationPatterns.tsx
+++ b/app/dataSources/validationPatterns.tsx
@@ -5,6 +5,10 @@ const validationPattern = {
         zod: z.string().regex(/^[a-zA-Z:()_0-9]+$/),
         string: "^[a-zA-Z:()_0-9]+$"
     },
+    createdBy: {
+        zod: z.string(),
+        string: "^[a-zA-Z0-9]+$"
+    },
     googleSheetUrl: {
         zod: z.url({
             protocol: /^https$/,


### PR DESCRIPTION
### Summary/Acceptance Criteria
This creates a `PUT` endpoint for updating the league configuration. As discussed with Jacob, this new endpoint exists in the same file as `POST` under the league file. The main differences between the PUT and the POST, aside from method, is how we trigger the 403.

First we are getting the all league configuration keys based on data that's passed in. Then, we're doing the following checks:
- If there are zero keys found, throw a 404
- If there are more than one key found, throw a 500
- If there is exactly one key, fetch the data for the one key

When data fetching completes, we get the createdBy value. We use that to check the league creator's ID against the session ID, ensuring that the person submitting the change request is the owner and is allowed to make the change. If they are, then make the update.

## Confirm
- [x] This PR has unit tests scenarios.
- [x] This PR is correctly linked to the relevant issue or milestone.
- [x] This PR has been locally QA'd.
- [ ] This PR has had it's db migrations run. (N/A)
- [ ] Update documentation. (N/A)
