### PR TITLE
Convert to transaction

### DIFF
--- a/__tests__/api/league/route.js
+++ b/__tests__/api/league/route.js
@@ -873,8 +873,6 @@ describe("PUT (unit tests)", () => {
         getAllKeys.mockImplementation(() => {
             return Promise.resolve([`league_configuration:${happyPathRequest.leagueStatus}:${happyPathRequest.leagueKey}`]);
         });
-
-        
     });
 
     afterEach(()=> {
@@ -1102,20 +1100,9 @@ describe("PUT (unit tests)", () => {
         expect(getAllKeys).toHaveBeenCalledWith(`league_configuration:*:${happyPathRequest.leagueKey}`);
     });
 
-    it("should construct the write key using database contestantLeagueDataKeyPrefix", async () => {
+    it("should construct the update key using database contestantLeagueDataKeyPrefix", async () => {
         // Arrange
-        const dbContestantLeagueDataKeyPrefix = `${happyPathRequest.leagueKey}:*`;
-        getLeagueConfigurationData.mockImplementation(() => {
-            return Promise.resolve({
-                createdBy: ourUserId,
-                leagueStatus: happyPathRequest.leagueStatus,
-                wikiPageUrl: "https://en.wikipedia.org/wiki/Page",
-                wikiApiUrl: "https://en.wikipedia.org/w/api.php",
-                castPhrase: "Cast",
-                competitingEntityName: "person",
-                contestantLeagueDataKeyPrefix: dbContestantLeagueDataKeyPrefix
-            });
-        });
+        const dbContestantLeagueDataKeyPrefix = "tvshowTestKey";
 
         const request = {
             cookies: {
@@ -1124,9 +1111,25 @@ describe("PUT (unit tests)", () => {
                 })
             },
             json: jest.fn().mockImplementation(async () => {
-                return happyPathRequest;
+                return {
+                    createdBy: ourUserId,
+                    leagueStatus: "active",
+                    leagueKey: happyPathRequest.leagueKey
+                }
             })
         };
+
+        getLeagueConfigurationData.mockImplementation(() => {
+            return Promise.resolve({
+                createdBy: ourUserId,
+                leagueStatus: happyPathRequest.leagueStatus,
+                wikiPageUrl: "https://en.wikipedia.org/wiki/Page",
+                wikiApiUrl: "https://en.wikipedia.org/w/api.php",
+                castPhrase: "Cast",
+                competitingEntityName: "person",
+                contestantLeagueDataKeyPrefix: `${dbContestantLeagueDataKeyPrefix}:*`
+            });
+        });
 
         // Act
         const response = await PUT(request);
@@ -1134,8 +1137,12 @@ describe("PUT (unit tests)", () => {
         // Assert
         expect(response).not.toBeNull();
         expect(response.status).toEqual(200);
+        expect(updateLeagueConfigurationData).not.toHaveBeenCalledWith(
+            `${happyPathRequest.leagueStatus}:${dbContestantLeagueDataKeyPrefix}`,
+            expect.anything()
+        );
         expect(updateLeagueConfigurationData).toHaveBeenCalledWith(
-            `league_configuration:${happyPathRequest.leagueStatus}:${happyPathRequest.leagueKey}`,
+            `${happyPathRequest.leagueStatus}:${happyPathRequest.leagueKey}`,
             expect.anything()
         );
     });

--- a/__tests__/api/league/route.js
+++ b/__tests__/api/league/route.js
@@ -6,7 +6,7 @@ jest.mock("google-auth-library");
 jest.mock("../../../app/dataSources/dbFetch");
 import * as sessionModule from "../../../app/api/session/session";
 import { OAuth2Client } from "google-auth-library";
-import { writeLeagueConfigurationData, getUser, getAllKeys, getLeagueConfigurationData, deleteLeagueConfigurationData } from "@/app/dataSources/dbFetch";
+import { writeLeagueConfigurationData, getUser, getAllKeys, getLeagueConfigurationData, updateLeagueConfigurationData } from "@/app/dataSources/dbFetch";
 import { POST, PUT } from "@/app/api/league/route.ts";
 
 let testAuthData = {}
@@ -33,7 +33,7 @@ writeLeagueConfigurationData.mockImplementation(() => {
     return () => { }
 });
 
-deleteLeagueConfigurationData.mockImplementation(() => {
+updateLeagueConfigurationData.mockImplementation(() => {
     return Promise.resolve();
 });
 
@@ -870,12 +870,6 @@ describe("PUT (unit tests)", () => {
             leagueKey: leagueConfigKey
         };
 
-        getUser.mockImplementation(() => {
-            return Promise.resolve({
-                role: "showAdmin"
-            });
-        });
-
         getAllKeys.mockImplementation(() => {
             return Promise.resolve([`league_configuration:${happyPathRequest.leagueStatus}:${happyPathRequest.leagueKey}`]);
         });
@@ -925,8 +919,8 @@ describe("PUT (unit tests)", () => {
         expect(response).not.toBeNull();
         expect(response.status).toEqual(200);
         expect(request.json).toHaveBeenCalledTimes(1);
-        expect(writeLeagueConfigurationData).toHaveBeenCalledTimes(1);
-        expect(writeLeagueConfigurationData).toHaveBeenCalledWith(
+        expect(updateLeagueConfigurationData).toHaveBeenCalledTimes(1);
+        expect(updateLeagueConfigurationData).toHaveBeenCalledWith(
             `league_configuration:${happyPathRequest.leagueStatus}:${dbContestantLeagueDataKeyPrefix}`,
             expect.objectContaining({
                 createdBy: happyPathRequest.createdBy,
@@ -1076,7 +1070,7 @@ describe("PUT (unit tests)", () => {
         // Assert
         expect(response).not.toBeNull();
         expect(response.status).toEqual(200);
-        expect(writeLeagueConfigurationData).toHaveBeenCalledWith(
+        expect(updateLeagueConfigurationData).toHaveBeenCalledWith(
             expect.anything(),
             expect.objectContaining({
                 wikiPageUrl: dbWikiPageUrl,
@@ -1140,96 +1134,9 @@ describe("PUT (unit tests)", () => {
         // Assert
         expect(response).not.toBeNull();
         expect(response.status).toEqual(200);
-        expect(writeLeagueConfigurationData).toHaveBeenCalledWith(
+        expect(updateLeagueConfigurationData).toHaveBeenCalledWith(
             `league_configuration:${happyPathRequest.leagueStatus}:${dbContestantLeagueDataKeyPrefix}`,
             expect.anything()
         );
-    });
-
-    it("should delete the preexisting configuration when leagueStatus changes", async () => {
-        // Arrange
-        const preexistingLeagueConfigurationKey = `league_configuration:inactive:${happyPathRequest.leagueKey}`;
-        const dbContestantLeagueDataKeyPrefix = `${happyPathRequest.leagueKey}:*`;
-        
-        getAllKeys.mockImplementation(() => {
-            return Promise.resolve([preexistingLeagueConfigurationKey]);
-        });
-
-        getLeagueConfigurationData.mockImplementation(() => {
-            return Promise.resolve({
-                createdBy: ourUserId,
-                leagueStatus: "inactive",
-                wikiPageUrl: "https://en.wikipedia.org/wiki/Page",
-                wikiApiUrl: "https://en.wikipedia.org/w/api.php",
-                castPhrase: "Cast",
-                competitingEntityName: "person",
-                contestantLeagueDataKeyPrefix: dbContestantLeagueDataKeyPrefix
-            });
-        });
-
-        const request = {
-            cookies: {
-                get: jest.fn().mockImplementation(()=> {
-                    return "testToken"
-                })
-            },
-            json: jest.fn().mockImplementation(async () => {
-                return {
-                    ...happyPathRequest,
-                    leagueStatus: "active"
-                };
-            })
-        };
-
-        // Act
-        const response = await PUT(request);
-
-        // Assert
-        expect(response).not.toBeNull();
-        expect(response.status).toEqual(200);
-        expect(deleteLeagueConfigurationData).toHaveBeenCalledWith(preexistingLeagueConfigurationKey);
-    });
-
-    it("should not delete the preexisting configuration when leagueStatus does not change", async () => {
-        // Arrange
-        const preexistingLeagueConfigurationKey = `league_configuration:active:${happyPathRequest.leagueKey}`;
-        const dbContestantLeagueDataKeyPrefix = `${happyPathRequest.leagueKey}:*`;
-        
-        getAllKeys.mockImplementation(() => {
-            return Promise.resolve([preexistingLeagueConfigurationKey]);
-        });
-
-        getLeagueConfigurationData.mockImplementation(() => {
-            return Promise.resolve({
-                createdBy: ourUserId,
-                leagueStatus: "active",
-                wikiPageUrl: "https://en.wikipedia.org/wiki/Page",
-                wikiApiUrl: "https://en.wikipedia.org/w/api.php",
-                castPhrase: "Cast",
-                competitingEntityName: "person",
-                contestantLeagueDataKeyPrefix: dbContestantLeagueDataKeyPrefix
-            });
-        });
-
-        deleteLeagueConfigurationData.mockClear();
-
-        const request = {
-            cookies: {
-                get: jest.fn().mockImplementation(()=> {
-                    return "testToken"
-                })
-            },
-            json: jest.fn().mockImplementation(async () => {
-                return happyPathRequest;
-            })
-        };
-
-        // Act
-        const response = await PUT(request);
-
-        // Assert
-        expect(response).not.toBeNull();
-        expect(response.status).toEqual(200);
-        expect(deleteLeagueConfigurationData).not.toHaveBeenCalled();
     });
 });

--- a/__tests__/api/league/route.js
+++ b/__tests__/api/league/route.js
@@ -919,7 +919,7 @@ describe("PUT (unit tests)", () => {
         expect(request.json).toHaveBeenCalledTimes(1);
         expect(updateLeagueConfigurationData).toHaveBeenCalledTimes(1);
         expect(updateLeagueConfigurationData).toHaveBeenCalledWith(
-            `league_configuration:${happyPathRequest.leagueStatus}:${happyPathRequest.leagueKey}`,
+            happyPathRequest.leagueKey,
             expect.objectContaining({
                 createdBy: happyPathRequest.createdBy,
                 leagueStatus: happyPathRequest.leagueStatus
@@ -1104,21 +1104,6 @@ describe("PUT (unit tests)", () => {
         // Arrange
         const dbContestantLeagueDataKeyPrefix = "tvshowTestKey";
 
-        const request = {
-            cookies: {
-                get: jest.fn().mockImplementation(()=> {
-                    return "testToken"
-                })
-            },
-            json: jest.fn().mockImplementation(async () => {
-                return {
-                    createdBy: ourUserId,
-                    leagueStatus: "active",
-                    leagueKey: happyPathRequest.leagueKey
-                }
-            })
-        };
-
         getLeagueConfigurationData.mockImplementation(() => {
             return Promise.resolve({
                 createdBy: ourUserId,
@@ -1131,8 +1116,20 @@ describe("PUT (unit tests)", () => {
             });
         });
 
+        const request = {
+            cookies: {
+                get: jest.fn().mockImplementation(()=> {
+                    return "testToken"
+                })
+            },
+            json: jest.fn().mockImplementation(async () => {
+                return happyPathRequest;
+            })
+        };
+        
         // Act
         const response = await PUT(request);
+        console.log(getAllKeys.mock.results[0].value);
 
         // Assert
         expect(response).not.toBeNull();
@@ -1141,8 +1138,10 @@ describe("PUT (unit tests)", () => {
             `${happyPathRequest.leagueStatus}:${dbContestantLeagueDataKeyPrefix}`,
             expect.anything()
         );
+        expect(getAllKeys.mock.calls[0][0]).toContain(`league_configuration:*:${happyPathRequest.leagueKey}`);
+        expect(getLeagueConfigurationData).toHaveBeenCalledWith(`league_configuration:${happyPathRequest.leagueStatus}:${happyPathRequest.leagueKey}`);
         expect(updateLeagueConfigurationData).toHaveBeenCalledWith(
-            `${happyPathRequest.leagueStatus}:${happyPathRequest.leagueKey}`,
+            happyPathRequest.leagueKey,
             expect.anything()
         );
     });

--- a/__tests__/api/league/route.js
+++ b/__tests__/api/league/route.js
@@ -921,7 +921,7 @@ describe("PUT (unit tests)", () => {
         expect(request.json).toHaveBeenCalledTimes(1);
         expect(updateLeagueConfigurationData).toHaveBeenCalledTimes(1);
         expect(updateLeagueConfigurationData).toHaveBeenCalledWith(
-            `league_configuration:${happyPathRequest.leagueStatus}:${dbContestantLeagueDataKeyPrefix}`,
+            `league_configuration:${happyPathRequest.leagueStatus}:${happyPathRequest.leagueKey}`,
             expect.objectContaining({
                 createdBy: happyPathRequest.createdBy,
                 leagueStatus: happyPathRequest.leagueStatus
@@ -1135,7 +1135,7 @@ describe("PUT (unit tests)", () => {
         expect(response).not.toBeNull();
         expect(response.status).toEqual(200);
         expect(updateLeagueConfigurationData).toHaveBeenCalledWith(
-            `league_configuration:${happyPathRequest.leagueStatus}:${dbContestantLeagueDataKeyPrefix}`,
+            `league_configuration:${happyPathRequest.leagueStatus}:${happyPathRequest.leagueKey}`,
             expect.anything()
         );
     });

--- a/app/api/league/route.ts
+++ b/app/api/league/route.ts
@@ -147,7 +147,7 @@ export async function PUT (request: NextRequest) {
         contestantLeagueDataKeyPrefix: leagueConfigurationData.contestantLeagueDataKeyPrefix,
         createdBy: userId
     };
-    await updateLeagueConfigurationData(preexistingLeagueConfigurationKey, leagueConfig);
+    await updateLeagueConfigurationData(body.leagueKey, leagueConfig);
 
     // return
     return NextResponse.json({"message": "updated"});

--- a/app/api/league/route.ts
+++ b/app/api/league/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import validationPattern from "@/app/dataSources/validationPatterns";
 import * as z from "zod/v4";
 import { decrypt } from "@/app/api/session/session";
-import { getUser, getAllKeys, getLeagueConfigurationData, writeLeagueConfigurationData, deleteLeagueConfigurationData } from "@/app/dataSources/dbFetch";
+import { getUser, getAllKeys, getLeagueConfigurationData, writeLeagueConfigurationData, updateLeagueConfigurationData } from "@/app/dataSources/dbFetch";
 import { unauthenticatedErrorMessage } from "@/app/api/constants/errors";
 
 interface decryptionPayload {
@@ -134,11 +134,7 @@ export async function PUT (request: NextRequest) {
         return NextResponse.json({"error": "you are not authorized to perform that action"}, {status: 403});
     }
 
-    if(leagueConfigurationData.leagueStatus !== body.leagueStatus){
-        await deleteLeagueConfigurationData(preexistingLeagueConfigurationKey);
-    }
-
-    // insert into db
+    // update in db
     const leagueConfigKey = `league_configuration:${body.leagueStatus}:${leagueConfigurationData.contestantLeagueDataKeyPrefix}`;
     const leagueConfig = {
         wikiPageUrl: leagueConfigurationData.wikiPageUrl,
@@ -152,8 +148,7 @@ export async function PUT (request: NextRequest) {
         contestantLeagueDataKeyPrefix: leagueConfigurationData.contestantLeagueDataKeyPrefix,
         createdBy: userId
     };
-
-    await writeLeagueConfigurationData(leagueConfigKey, leagueConfig);
+    await updateLeagueConfigurationData(leagueConfigKey, leagueConfig);
 
     // return
     return NextResponse.json({"message": "updated"});

--- a/app/api/league/route.ts
+++ b/app/api/league/route.ts
@@ -135,7 +135,6 @@ export async function PUT (request: NextRequest) {
     }
 
     // update in db
-    const leagueConfigKey = `league_configuration:${body.leagueStatus}:${leagueConfigurationData.contestantLeagueDataKeyPrefix}`;
     const leagueConfig = {
         wikiPageUrl: leagueConfigurationData.wikiPageUrl,
         wikiApiUrl: leagueConfigurationData.wikiApiUrl,
@@ -148,7 +147,7 @@ export async function PUT (request: NextRequest) {
         contestantLeagueDataKeyPrefix: leagueConfigurationData.contestantLeagueDataKeyPrefix,
         createdBy: userId
     };
-    await updateLeagueConfigurationData(leagueConfigKey, leagueConfig);
+    await updateLeagueConfigurationData(`${preexistingLeagueConfigurationKey}:*`, leagueConfig);
 
     // return
     return NextResponse.json({"message": "updated"});

--- a/app/api/league/route.ts
+++ b/app/api/league/route.ts
@@ -147,7 +147,7 @@ export async function PUT (request: NextRequest) {
         contestantLeagueDataKeyPrefix: leagueConfigurationData.contestantLeagueDataKeyPrefix,
         createdBy: userId
     };
-    await updateLeagueConfigurationData(`${preexistingLeagueConfigurationKey}:*`, leagueConfig);
+    await updateLeagueConfigurationData(preexistingLeagueConfigurationKey, leagueConfig);
 
     // return
     return NextResponse.json({"message": "updated"});

--- a/app/dataSources/dbFetch.tsx
+++ b/app/dataSources/dbFetch.tsx
@@ -107,12 +107,14 @@ export async function updateLeagueConfigurationData(leagueConfigurationKey: stri
         url: process.env.KV_REST_API_URL,
         token: process.env.KV_REST_API_TOKEN
     });
-    
 
+    const leagueStatusAndKeyPrefix = leagueConfigurationKey.replace("league_configuration:", "");
+    const index = leagueStatusAndKeyPrefix.indexOf(":");
+    const leagueKeyWithoutStatus = leagueStatusAndKeyPrefix.slice(index + 1);
     const leagueConfigString = JSON.stringify(leagueConfiguration);
     const tx = redis.multi();
     tx.del(leagueConfigurationKey);
-    const newLeagueConfigKey = `league_configuration:${leagueConfiguration.leagueStatus}:${leagueConfiguration.contestantLeagueDataKeyPrefix}`;
+    const newLeagueConfigKey = `league_configuration:${leagueConfiguration.leagueStatus}:${leagueKeyWithoutStatus}`;
     tx.json.set(newLeagueConfigKey, "$", leagueConfigString);
     await tx.exec();
 }

--- a/app/dataSources/dbFetch.tsx
+++ b/app/dataSources/dbFetch.tsx
@@ -95,6 +95,26 @@ export async function writeLeagueConfigurationData(leagueConfigurationKey: strin
     await redis.json.set(leagueConfigurationKey, "$", leagueConfigString)
 }
 
+export async function updateLeagueConfigurationData(leagueConfigurationKey: string, leagueConfiguration: ILeagueConfigurationData): Promise<void> {
+    if (leagueConfigurationKey === undefined) {
+        throw new Error("Unable to writeLeagueConfigurationData. Provided param 'leagueConfigurationKey' is undefined but must have a value\"");
+    };
+    if (leagueConfiguration === undefined) {
+        throw new Error("Unable to writeLeagueConfigurationData. Provided param 'leagueConfiguration' is undefined but must have a value\"");
+    };
+
+    const redis = new Redis({
+        url: process.env.KV_REST_API_URL,
+        token: process.env.KV_REST_API_TOKEN
+    });
+
+    const leagueConfigString = JSON.stringify(leagueConfiguration);
+    const tx = redis.multi();
+    tx.del(leagueConfigurationKey);
+    tx.json.set(leagueConfigurationKey, "$", leagueConfigString);
+    await tx.exec();
+}
+
 
 
 export async function getLeagueConfigurationData(leagueConfigurationKey: string): Promise<ILeagueConfigurationData> {

--- a/app/dataSources/dbFetch.tsx
+++ b/app/dataSources/dbFetch.tsx
@@ -111,9 +111,7 @@ export async function updateLeagueConfigurationData(leagueConfigurationKey: stri
 
     const leagueConfigString = JSON.stringify(leagueConfiguration);
     const tx = redis.multi();
-    if(tx.exists(leagueConfigurationKey)){
-        tx.del(leagueConfigurationKey);
-    }
+    tx.del(leagueConfigurationKey);
     const newLeagueConfigKey = `league_configuration:${leagueConfiguration.leagueStatus}:${leagueConfiguration.contestantLeagueDataKeyPrefix}`;
     tx.json.set(newLeagueConfigKey, "$", leagueConfigString);
     await tx.exec();

--- a/app/dataSources/dbFetch.tsx
+++ b/app/dataSources/dbFetch.tsx
@@ -107,13 +107,15 @@ export async function updateLeagueConfigurationData(leagueConfigurationKey: stri
         url: process.env.KV_REST_API_URL,
         token: process.env.KV_REST_API_TOKEN
     });
+    
 
     const leagueConfigString = JSON.stringify(leagueConfiguration);
     const tx = redis.multi();
     if(tx.exists(leagueConfigurationKey)){
         tx.del(leagueConfigurationKey);
     }
-    tx.json.set(leagueConfigurationKey, "$", leagueConfigString);
+    const newLeagueConfigKey = `league_configuration:${leagueConfiguration.leagueStatus}:${leagueConfiguration.contestantLeagueDataKeyPrefix}`;
+    tx.json.set(newLeagueConfigKey, "$", leagueConfigString);
     await tx.exec();
 }
 

--- a/app/dataSources/dbFetch.tsx
+++ b/app/dataSources/dbFetch.tsx
@@ -100,7 +100,7 @@ export async function updateLeagueConfigurationData(leagueConfigurationKey: stri
         throw new Error("Unable to writeLeagueConfigurationData. Provided param 'leagueConfigurationKey' is undefined but must have a value\"");
     };
     if (leagueConfiguration === undefined) {
-        throw new Error("Unable to writeLeagueConfigurationData. Provided param 'leagueConfiguration' is undefined but must have a value\"");
+        throw new Error("Unable to writeLeagueConfigurationData. Provided param 'leagueConfiguration' is undefined but must have a value");
     };
 
     const redis = new Redis({

--- a/app/dataSources/dbFetch.tsx
+++ b/app/dataSources/dbFetch.tsx
@@ -110,7 +110,9 @@ export async function updateLeagueConfigurationData(leagueConfigurationKey: stri
 
     const leagueConfigString = JSON.stringify(leagueConfiguration);
     const tx = redis.multi();
-    tx.del(leagueConfigurationKey);
+    if(tx.json.get(leagueConfigurationKey) !== null){
+        tx.del(leagueConfigurationKey);
+    }
     tx.json.set(leagueConfigurationKey, "$", leagueConfigString);
     await tx.exec();
 }

--- a/app/dataSources/dbFetch.tsx
+++ b/app/dataSources/dbFetch.tsx
@@ -110,7 +110,7 @@ export async function updateLeagueConfigurationData(leagueConfigurationKey: stri
 
     const leagueConfigString = JSON.stringify(leagueConfiguration);
     const tx = redis.multi();
-    if(tx.json.get(leagueConfigurationKey) !== null){
+    if(tx.exists(leagueConfigurationKey)){
         tx.del(leagueConfigurationKey);
     }
     tx.json.set(leagueConfigurationKey, "$", leagueConfigString);


### PR DESCRIPTION
### Summary/Acceptance Criteria
This updates the original update league config endpoint logic from individual functions to a transaction that combines delete and set. I removed the tests that test individual functions for write and delete in the PUT tests and didn't add more because those would be integration tests. We won't be testing Redis.

## Confirm
- [x] This PR has unit tests scenarios.
- [x] This PR is correctly linked to the relevant issue or milestone.
- [ ] This PR has been locally QA'd.
- [ ] This PR has had it's db migrations run. (N/A)
- [ ] Update documentation. (N/A)
