### PR TITLE
Feature/strip bb in competing entity

### DIFF
--- a/__tests__/parsers/bigBrotherEntityParser.js
+++ b/__tests__/parsers/bigBrotherEntityParser.js
@@ -414,3 +414,18 @@ describe("parseBigBrotherEntities", () => {
     });
 });
 
+describe("getContestantName", () => {
+    it("should return just the row.name when it exists", () => {
+        // Arrange
+        const aRow = {
+            name: "I have a name"
+        }
+
+        // Act
+        const result = getContestantName(aRow);
+
+        // Assert
+        expect(result).toBe(aRow.name);
+    });
+});
+

--- a/__tests__/parsers/bigBrotherEntityParser.js
+++ b/__tests__/parsers/bigBrotherEntityParser.js
@@ -440,5 +440,20 @@ describe("getContestantName", () => {
         // Assert
         expect(result).toBe(aRow.name2);
     });
+
+    it("should remove every thing strarting from 'big brother' text when it exists", () => {
+        // Arrange
+        const nameTextBeforeBB = "I have a name";
+        const nameTextWithBBAndBeyond = "big brother and some other stuff";
+        const aRow = {
+            name: nameTextBeforeBB + nameTextWithBBAndBeyond
+        }
+
+        // Act
+        const result = getContestantName(aRow);
+
+        // Assert
+        expect(result).toBe(nameTextBeforeBB);
+    });
 });
 

--- a/__tests__/parsers/bigBrotherEntityParser.js
+++ b/__tests__/parsers/bigBrotherEntityParser.js
@@ -1,4 +1,4 @@
-import parseBigBrotherEntities from "@/app/parsers/bigBrotherEntityParser";
+import parseBigBrotherEntities, { getContestantName } from "@/app/parsers/bigBrotherEntityParser";
 
 describe("parseBigBrotherEntities", () => {
     it("should run", () => {

--- a/__tests__/parsers/bigBrotherEntityParser.js
+++ b/__tests__/parsers/bigBrotherEntityParser.js
@@ -455,5 +455,21 @@ describe("getContestantName", () => {
         // Assert
         expect(result).toBe(nameTextBeforeBB);
     });
+
+    it("should remove every thing strarting from 'Big Brother' text when it exists", () => {
+        // Arrange
+        const nameTextBeforeBB = "I have a name";
+        // casing matters!
+        const nameTextWithBBAndBeyond = "Big Brother and some other stuff";
+        const aRow = {
+            name: nameTextBeforeBB + nameTextWithBBAndBeyond
+        }
+
+        // Act
+        const result = getContestantName(aRow);
+
+        // Assert
+        expect(result).toBe(nameTextBeforeBB);
+    });
 });
 

--- a/__tests__/parsers/bigBrotherEntityParser.js
+++ b/__tests__/parsers/bigBrotherEntityParser.js
@@ -427,5 +427,18 @@ describe("getContestantName", () => {
         // Assert
         expect(result).toBe(aRow.name);
     });
+
+    it("should fall back to name2 when row.name is undefined", () => {
+        // Arrange
+        const aRow = {
+            name2: "I have a name"
+        }
+
+        // Act
+        const result = getContestantName(aRow);
+
+        // Assert
+        expect(result).toBe(aRow.name2);
+    });
 });
 

--- a/app/parsers/bigBrotherEntityParser.tsx
+++ b/app/parsers/bigBrotherEntityParser.tsx
@@ -30,7 +30,7 @@ export default function parseBigBrotherEntities(contestantData :ITableRowData[])
             throw new ReferenceError("Status is either null or undefined and it should not be");
         }
 
-        const teamName = element.name || element.name2;
+        const teamName = getContestantName(element);
 
         let isParticipating = true;
         let eliminationOrder = 0;

--- a/app/parsers/bigBrotherEntityParser.tsx
+++ b/app/parsers/bigBrotherEntityParser.tsx
@@ -113,5 +113,10 @@ export default function parseBigBrotherEntities(contestantData :ITableRowData[])
 export function getContestantName(row: string): string {
     const rawName = row.name || row.name2;
 
+    if (rawName.includes("big brother")) {
+        const indexOfBigBrother = rawName.indexOf("big brother");
+        return rawName.substring(0, indexOfBigBrother);
+    }
+
     return rawName;
 }

--- a/app/parsers/bigBrotherEntityParser.tsx
+++ b/app/parsers/bigBrotherEntityParser.tsx
@@ -110,7 +110,7 @@ export default function parseBigBrotherEntities(contestantData :ITableRowData[])
     return contestantsSortedByEliminationOrder;
 }
 
-export function getContestantName(row: string): string {
+export function getContestantName(row: ITableRowData): string {
     const rawName = row.name || row.name2;
 
     const lowerCaseRawName = rawName.toLowerCase();

--- a/app/parsers/bigBrotherEntityParser.tsx
+++ b/app/parsers/bigBrotherEntityParser.tsx
@@ -113,8 +113,9 @@ export default function parseBigBrotherEntities(contestantData :ITableRowData[])
 export function getContestantName(row: string): string {
     const rawName = row.name || row.name2;
 
-    if (rawName.includes("big brother")) {
-        const indexOfBigBrother = rawName.indexOf("big brother");
+    const lowerCaseRawName = rawName.toLowerCase();
+    if (lowerCaseRawName.includes("big brother")) {
+        const indexOfBigBrother = lowerCaseRawName.indexOf("big brother");
         return rawName.substring(0, indexOfBigBrother);
     }
 

--- a/app/parsers/bigBrotherEntityParser.tsx
+++ b/app/parsers/bigBrotherEntityParser.tsx
@@ -109,3 +109,9 @@ export default function parseBigBrotherEntities(contestantData :ITableRowData[])
 
     return contestantsSortedByEliminationOrder;
 }
+
+export function getContestantName(row: string): string {
+    const rawName = row.name || row.name2;
+
+    return rawName;
+}


### PR DESCRIPTION
### Summary/Acceptance Criteria
So after creating the league it became clear that Angela's name was getting muddled with a link to her previous appearance on BB26 so I added this little hack which at the time of writing I think should be fairly stable.

### Screenshots
_Before:_
<img width="316" height="90" alt="image" src="https://github.com/user-attachments/assets/904f33c0-0730-4be3-8610-b7831b0d5748" />

_After:_
<img width="184" height="86" alt="image" src="https://github.com/user-attachments/assets/ab8d85e9-92e7-43c5-8fee-e84a42dad392" />



## Confirm
- [x] This PR has unit tests scenarios.
- [x] This PR is correctly linked to the relevant issue or milestone.
- [x] This PR has been locally QA'd.
- [ ] This PR has had it's db migrations run. (N/A no real migrations for this, because we are just filtering from Wikipedia)
- [ ] Update documentation. (Don't think this is necessary at this time)
